### PR TITLE
Pronounce "g" as Jee instead of Gee

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -66,6 +66,6 @@ title: FAQ
     <p>gRPC largely follows HTTP semantics over HTTP/2 but we explicitly allow for full-duplex streaming. We diverge from typical REST conventions as we use static paths for performance reasons during call dispatch as parsing call parameters from paths, query parameters and payload body adds latency and complexity. We have also formalized a set of errors that we believe are more directly applicable to API uses cases than the HTTP status codes.</p>
 
     <h4>How do you pronounce gRPC?</h4>
-    <p>Gee-Arr-Pee-See</p>
+    <p>Jee-Arr-Pee-See</p>
 
 </div>


### PR DESCRIPTION
While it is true that "Ge" is pronounced with a "j" sound (like George), we should probably just use J.
