### PR TITLE
Replace links to grpc repo with branch variable

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -1,1 +1,1 @@
-branch: release-0_10
+grpc_release_branch: release-0_10

--- a/_includes/c-lang-list.html
+++ b/_includes/c-lang-list.html
@@ -1,8 +1,8 @@
 <a href="https://github.com/grpc/grpc">C</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/cpp">C++</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/node">Node.js</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/python">Python</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/ruby">Ruby</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/objective-c">Objective-C</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/php">PHP</a> and 
-<a href="https://github.com/grpc/grpc/tree/master/src/csharp">C#</a>.
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/cpp">C++</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/node">Node.js</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/python">Python</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/ruby">Ruby</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/objective-c">Objective-C</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/php">PHP</a> and 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp">C#</a>.

--- a/_includes/lang-list.html
+++ b/_includes/lang-list.html
@@ -1,10 +1,10 @@
 <a href="https://github.com/grpc/grpc">C</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/cpp">C++</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/cpp">C++</a>, 
 <a href="https://github.com/grpc/grpc-java">Java</a>, 
 <a href="https://github.com/grpc/grpc-go">Go</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/node">Node.js</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/python">Python</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/ruby">Ruby</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/objective-c">Objective-C</a>, 
-<a href="https://github.com/grpc/grpc/tree/master/src/php">PHP</a> and 
-<a href="https://github.com/grpc/grpc/tree/master/src/csharp">C#</a>.
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/node">Node.js</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/python">Python</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/ruby">Ruby</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/objective-c">Objective-C</a>, 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/php">PHP</a> and 
+<a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp">C#</a>.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ To get up and running with gRPC straight away, see the quick start for your chos
 * [PHP](/docs/installation/php.html)
 
 You can find out about the gRPC source code repositories in
-[grpc](https://github.com/grpc/grpc). Most of our example code (plus more draft documentation) lives in the [examples](https://github.com/grpc/grpc/tree/master/examples) directory.
+[grpc](https://github.com/grpc/grpc). Most of our example code (plus more draft documentation) lives in the [examples](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples) directory.
 
 <!--=========================================================================-->
 ## What is gRPC?
@@ -447,7 +447,7 @@ Running the appropriate command for your OS regenerates the following files in t
 
   </div>
 <div id="objective-c_generate">
-For simplicity, we've provided a [Podspec file](https://github.com/grpc/grpc/blob/master/examples/objective-c/helloworld/HelloWorld.podspec) that runs protoc for you with the appropriate plugin, input, and output, and describes how to compile the generated files. You just need to run in `examples/objective-c/route_guide`:
+For simplicity, we've provided a [Podspec file](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/objective-c/helloworld/HelloWorld.podspec) that runs protoc for you with the appropriate plugin, input, and output, and describes how to compile the generated files. You just need to run in `examples/objective-c/route_guide`:
 
 ```
 $ pod install
@@ -534,7 +534,7 @@ message, as specified in our interface definition.</li>
 </ol>
   </div>
   <div id="cpp_service">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/greeter_server.cc">greeter_server.cc</a>
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/helloworld/greeter_server.cc">greeter_server.cc</a>
 implements our <code>Greeter</code> service's required behaviour.</p>
 
 <p>As you can see, the class <code>GreeterServiceImpl</code> implements the interface
@@ -571,7 +571,7 @@ message, as specified in our interface definition.</li>
 </ol>
   </div>
   <div id="python_service">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server.py">greeter_server.py</a> implements our <code>Greeter</code> service's required behaviour.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/helloworld/greeter_server.py">greeter_server.py</a> implements our <code>Greeter</code> service's required behaviour.
 
 <p>As you can see, the class <code>Greeter</code> implements the interface
 <code>helloworld_pb2.EarlyAdopterGreeterServicer</code> that we <a href="#generating">generated</a> from our proto
@@ -609,7 +609,7 @@ message, as specified in our interface definition.</li>
 
   </div>
   <div id="ruby_service">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/ruby/greeter_server.rb">greeter&lowbar;server.rb</a> implements our <code>Greeter</code> service's required behaviour.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/ruby/greeter_server.rb">greeter&lowbar;server.rb</a> implements our <code>Greeter</code> service's required behaviour.
 <p>Our server has a <code>GreeterServer</code> class, which implements the <code>GreeterServer</code> interface that we <a href="#generating">generated</a> from our proto
 service definition by implementing the method <code>SayHello</code>:</p>
 <pre>class GreeterServer < Helloworld::Greeter::Service
@@ -623,7 +623,7 @@ message, as specified in our interface definition, then return.</p>
 
   </div>
   <div id="node_service">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/node/greeter_server.js">greeter&lowbar;server.js</a> implements our <code>Greeter</code> service's required behaviour.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/node/greeter_server.js">greeter&lowbar;server.js</a> implements our <code>Greeter</code> service's required behaviour.
 <p>Our server implements the <code>Greeter</code>service from our
 service definition by implementing the method <code>SayHello</code>:</p>
 <pre>
@@ -635,7 +635,7 @@ function sayHello(call, callback) {
 
   </div>
   <div id="csharp_service">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/csharp/GreeterServer/Program.cs">GreeterServer/Program.cs</a> implements our <code>Greeter</code> service's required behaviour.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/GreeterServer/Program.cs">GreeterServer/Program.cs</a> implements our <code>Greeter</code> service's required behaviour.
 <p>Our server has a <code>GreeterImpl</code> class, which implements the <code>IGreeter</code> interface that we <a href="#generating">generated</a> from our proto
 service definition by implementing the method <code>SayHello</code>:</p>
 <pre>
@@ -697,7 +697,7 @@ provides this for our Java example.</p>
 
   </div>
   <div id="cpp_server">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/greeter_server.cc">greeter_server.cc</a>
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/helloworld/greeter_server.cc">greeter_server.cc</a>
 also provides this for our C++ example.</p>
 <pre>void RunServer() {
   std::string server_address("0.0.0.0:50051");
@@ -714,7 +714,7 @@ also provides this for our C++ example.</p>
 </pre>
   </div>
   <div id="python_server">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server.py">greeter_server.py</a>
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/helloworld/greeter_server.py">greeter_server.py</a>
 also provides this for our C++ example.</p>
 <pre>  server = helloworld_pb2.early_adopter_create_Greeter_server(
       Greeter(), 50051, None, None)
@@ -747,7 +747,7 @@ func main() {
 
   </div>
   <div id="ruby_server">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/ruby/greeter_server.rb">greeter&lowbar;server.rb</a> also provides this for our Ruby example.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/ruby/greeter_server.rb">greeter&lowbar;server.rb</a> also provides this for our Ruby example.
 <pre>
 def main
   s = GRPC::RpcServer.new
@@ -759,7 +759,7 @@ end
 
   </div>
   <div id="node_server">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/node/greeter_server.js">greeter&lowbar;server.js</a> also provides this for our Node.js example.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/node/greeter_server.js">greeter&lowbar;server.js</a> also provides this for our Node.js example.
 <pre>
 function main() {
   var server = new Server({
@@ -774,7 +774,7 @@ function main() {
 
   </div>
   <div id="csharp_server">
-<p><a href="https://github.com/grpc/grpc/blob/master/examples/csharp/GreeterServer/Program.cs">GreeterServer/Program.cs</a> also provides this for our C# example.
+<p><a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/GreeterServer/Program.cs">GreeterServer/Program.cs</a> also provides this for our C# example.
 <pre>Server server = new Server();
 server.AddServiceDefinition(Greeter.BindService(new GreeterImpl()));
 int port = server.AddListeningPort("localhost", 50051);
@@ -965,13 +965,13 @@ Now we can contact the service and obtain a greeting:
     }
   }</pre>
 
-<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/greeter_client.cc">greeter_client.cc</a>.</p>
+<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/helloworld/greeter_client.cc">greeter_client.cc</a>.</p>
   </div>
   <div id="python_call">
 <pre>response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), _TIMEOUT_SECONDS)
 print "Greeter client received: " + response.message
 </pre>
-<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_client.py">greeter_client.py</a>.</p>
+<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/helloworld/greeter_client.py">greeter_client.py</a>.</p>
 
 </div>
   <div id="go_call">
@@ -988,20 +988,20 @@ log.Printf("Greeting: %s", r.Message)</pre>
   message = stub.say&lowbar;hello(Helloworld::HelloRequest.new(name: user)).message
   p "Greeting: #{message}"
 </pre>
-<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/master/examples/ruby/greeter_client.rb">greeter_client.rb</a>.</p>
+<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/ruby/greeter_client.rb">greeter_client.rb</a>.</p>
 
   </div>
   <div id="node_call">
 <pre>  client.sayHello({name: user}, function(err, response) {
     console.log('Greeting:', response.message);
   });</pre>
-<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/master/examples/node/greeter_client.js">greeter_client.js</a>.</p>
+<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/node/greeter_client.js">greeter_client.js</a>.</p>
 
   </div>
   <div id="csharp_call">
 <pre>var reply = client.SayHello(new HelloRequest.Builder { Name = user }.Build());
 Console.WriteLine("Greeting: " + reply.Message);</pre>
-<p>You can see the complete example code in <a href="https://github.com/grpc/grpc/blob/master/examples/csharp/GreeterClient/Program.cs">GreeterClient/Program.cs</a>.</p>
+<p>You can see the complete example code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/GreeterClient/Program.cs">GreeterClient/Program.cs</a>.</p>
 
   </div>
   <div id="objective-c_call">
@@ -1010,7 +1010,7 @@ Console.WriteLine("Greeting: " + reply.Message);</pre>
     [client sayHelloWithRequest:request handler:^(HLWHelloReply *response, NSError *error) {
       NSLog(@"%@", response.message);
     }];</pre>
-<p>You can see the complete example code in <a href="https://github.com/grpc/grpc/tree/master/examples/objective-c/helloworld">examples/objective-c/helloworld</a>.</p>
+<p>You can see the complete example code in <a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/objective-c/helloworld">examples/objective-c/helloworld</a>.</p>
 
   </div>
   <div id="php_call">
@@ -1019,7 +1019,7 @@ Console.WriteLine("Greeting: " + reply.Message);</pre>
   list($reply, $status) = $client->SayHello($request)->wait();
   $message = $reply->getMessage();</pre>
 
-<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/master/examples/php/greeter_client.php">greeter_client.php</a>.</p>
+<p>You can see the complete client code in <a href="https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/php/greeter_client.php">greeter_client.php</a>.</p>
 
   </div>
 </div>

--- a/docs/installation/c.md
+++ b/docs/installation/c.md
@@ -9,11 +9,11 @@ title: C++ Quick Start
 ## Installation
 
 To install gRPC on your system, follow the instructions here:
-[https://github.com/grpc/grpc/blob/master/INSTALL](https://github.com/grpc/grpc/blob/master/INSTALL).
+[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/INSTALL](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/INSTALL).
 
 ## Hello C++ gRPC!
 
-Here's how to build and run the C++ implementation of the [Hello World](https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto) example used in the [Overview](/docs/index.shtml).
+Here's how to build and run the C++ implementation of the [Hello World](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/helloworld.proto) example used in the [Overview](/docs/index.shtml).
 
 The example code for this and our other examples lives in the `examples`
 directory. Clone this repository to your local machine by running the
@@ -47,9 +47,9 @@ $ protoc -I ../../protos/ --cpp_out=. ../../protos/helloworld.proto
 
 ### Client and server implementations
 
-The client implementation is at [greeter_client.cc](https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/greeter_client.cc).
+The client implementation is at [greeter_client.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/helloworld/greeter_client.cc).
 
-The server implementation is at [greeter_server.cc](https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/greeter_server.cc).
+The server implementation is at [greeter_server.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/helloworld/greeter_server.cc).
 
 ### Try it!
 Build client and server:

--- a/docs/installation/csharp.md
+++ b/docs/installation/csharp.md
@@ -9,7 +9,7 @@ title: C# Quick Start
 
 This document shows you how to install and build a C# implementation of the example used in the [Overview](/docs/index.shtml). For this sample, we've already generated the server and client stubs from `helloworld.proto`. Example projects depend on NuGet packages `Grpc` and `Google.ProtocolBuffers` which have been already added to the project for you.
 
-You can see full installation instructions and notes for the current version of gRPC C# in the C# [README](https://github.com/grpc/grpc/tree/master/src/csharp).
+You can see full installation instructions and notes for the current version of gRPC C# in the C# [README](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp).
 
 Prerequisites
 -------------
@@ -46,7 +46,7 @@ Build
 - Install gRPC C Core using instructions in [homebrew-grpc](https://github.com/grpc/homebrew-grpc).
 
 - gRPC C# depends on the native shared library `libgrpc_csharp_ext.so`. To make it visible
-  to Mono runtime, follow instructions in [Using gRPC C# on Linux](https://github.com/grpc/grpc/tree/master/src/csharp#usage-linux-mono)
+  to Mono runtime, follow instructions in [Using gRPC C# on Linux](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-linux-mono)
 
 - Open solution `Greeter.sln` in MonoDevelop (you need to manually restore dependencies by using `mono nuget.exe restore` if you don't have NuGet add-in)
 
@@ -54,7 +54,7 @@ Build
 
 **MacOS (Mono)**
 
-- See [Using gRPC C# on MacOS](https://github.com/grpc/grpc/tree/master/src/csharp#usage-macos-mono) for more info
+- See [Using gRPC C# on MacOS](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-macos-mono) for more info
   on MacOS support.
 
 Try it!

--- a/docs/installation/node.md
+++ b/docs/installation/node.md
@@ -57,7 +57,7 @@ Try it!
 Note
 ----
 
-The <a href="https://github.com/grpc/grpc/tree/master/examples/node">examples/node</a> directory has its own copy of `helloworld.proto` because it currently depends on
+The <a href="https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/node">examples/node</a> directory has its own copy of `helloworld.proto` because it currently depends on
 some Protocol Buffer 2.0 syntax that is deprecated in Protocol Buffer 3.0.
 
 Tutorial

--- a/docs/installation/objective-c.md
+++ b/docs/installation/objective-c.md
@@ -13,7 +13,7 @@ To run this example you should have [Cocoapods](https://cocoapods.org/#install) 
 
 ## Hello Objective-C gRPC!
 
-Here's how to build and run the Objective-C implementation of the [Hello World](https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto) example used in the [Overview](/docs/index.html).
+Here's how to build and run the Objective-C implementation of the [Hello World](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/helloworld.proto) example used in the [Overview](/docs/index.html).
 
 The example code for this and our other examples lives in the `examples`
 directory. Clone this repository to your local machine by running the

--- a/docs/installation/python.md
+++ b/docs/installation/python.md
@@ -9,7 +9,7 @@ title: Python Quick Start
 
 ### Install gRPC
 Make sure you have built gRPC Python from source on your system. Follow the instructions here:
-[https://github.com/grpc/grpc/blob/master/src/python/README.md](https://github.com/grpc/grpc/blob/master/src/python/README.md).
+[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/src/python/README.md](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/src/python/README.md).
 
 This gives you a python virtual environment with installed gRPC Python
 in `GRPC_ROOT/python2.7_virtual_environment`. GRPC_ROOT is the path to which you
@@ -45,7 +45,7 @@ types as protocol buffer message types. Both the client and the
 server use interface code generated from the service definition.
 
 Here's our example service definition, defined using protocol buffers IDL in
-[helloworld.proto](https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto). The `Greeting`
+[helloworld.proto](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/helloworld.proto). The `Greeting`
 service has one method, `hello`, that lets the server receive a single
 `HelloRequest`
 message from the remote client containing the user's name, then send back
@@ -102,7 +102,7 @@ been generated for you (helloworld_pb2.py).
 
 ### The client
 
-Client-side code can be found in [greeter_client.py](https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_client.py).
+Client-side code can be found in [greeter_client.py](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/helloworld/greeter_client.py).
 
 You can run the client using:
 
@@ -113,7 +113,7 @@ $ ./run_client.sh
 
 ### The server
 
-Server side code can be found in [greeter_server.py](https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server.py). 
+Server side code can be found in [greeter_server.py](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/helloworld/greeter_server.py). 
 
 You can run the server using:
 

--- a/docs/installation/ruby.md
+++ b/docs/installation/ruby.md
@@ -34,7 +34,7 @@ $ gem install bundler # if you don't already have bundler available
 $ bundle install
 ```
 
-You can find more detailed installation instructions in the [grpc repo](https://github.com/grpc/grpc/tree/master/src/ruby).
+You can find more detailed installation instructions in the [grpc repo](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/ruby).
 
 Try it!
 -------
@@ -60,5 +60,5 @@ Tutorial
 
 You can find a more detailed tutorial in [gRPC Basics: Ruby](/docs/tutorials/basic/ruby.html)
 
-[helloworld.proto]:https://github.com/grpc/grpc/blob/master/examples/protos/helloworld.proto
+[helloworld.proto]:https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/helloworld.proto
 [RVM]:https://www.rvm.io/

--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -27,7 +27,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/cpp/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/cpp/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/cpp/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/cpp/route_guide). To download the example, clone the `grpc` repository by running the following command:
 ```
 $ git clone https://github.com/grpc/grpc.git
 ```
@@ -42,7 +42,7 @@ You also should have the relevant tools installed to generate the server and cli
 
 ## Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -105,7 +105,7 @@ message Point {
 
 Next we need to generate the gRPC client and server interfaces from our .proto service definition. We do this using the protocol buffer compiler `protoc` with a special gRPC C++ plugin.
 
-For simplicity, we've provided a [makefile](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/cpp/route_guide/Makefile) that runs `protoc` for you with the appropriate plugin, input, and output (if you want to run this yourself, make sure you've installed protoc and followed the gRPC code [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/INSTALL) first):
+For simplicity, we've provided a [makefile](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/route_guide/Makefile) that runs `protoc` for you with the appropriate plugin, input, and output (if you want to run this yourself, make sure you've installed protoc and followed the gRPC code [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/INSTALL) first):
 
 ```
 $ make route_guide.grpc.pb.cc route_guide.pb.cc
@@ -140,7 +140,7 @@ There are two parts to making our `RouteGuide` service do its job:
 - Implementing the service interface generated from our service definition: doing the actual "work" of our service.
 - Running a gRPC server to listen for requests from clients and return the service responses.
 
-You can find our example `RouteGuide` server in [examples/cpp/route_guide/route_guide_server.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/cpp/route_guide/route_guide_server.cc). Let's take a closer look at how it works.
+You can find our example `RouteGuide` server in [examples/cpp/route_guide/route_guide_server.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/route_guide/route_guide_server.cc). Let's take a closer look at how it works.
 
 ### Implementing RouteGuide
 
@@ -250,7 +250,7 @@ As you can see, we build and start our server using a `ServerBuilder`. To do thi
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating a C++ client for our `RouteGuide` service. You can see our complete example client code in [examples/cpp/route_guide/route_guide_client.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/cpp/route_guide/route_guide_client.cc).
+In this section, we'll look at creating a C++ client for our `RouteGuide` service. You can see our complete example client code in [examples/cpp/route_guide/route_guide_client.cc](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/cpp/route_guide/route_guide_client.cc).
 
 ### Creating a stub
 

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -28,7 +28,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/csharp/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/csharp/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/csharp/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/csharp/route_guide). To download the example, clone the `grpc` repository by running the following command:
 ```shell
 $ git clone https://github.com/grpc/grpc.git
 ```
@@ -40,11 +40,11 @@ On Windows, you should not need to do anything besides opening the solution. All
 for you automatically by the `Grpc` NuGet package upon building the solution.
 
 On Linux (or MacOS), you will first need to install protobuf and gRPC C Core using Linuxbrew (or Homebrew) tool in order to be 
-able to generate the server and client interface code and run the examples. Follow the instructions for [Linux](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/src/csharp#usage-linux-mono) or [MacOS](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/src/csharp#usage-macos-mono).
+able to generate the server and client interface code and run the examples. Follow the instructions for [Linux](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-linux-mono) or [MacOS](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-macos-mono).
 
 ## Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/csharp/route_guide/RouteGuide/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/csharp/route_guide/RouteGuide/protos/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/csharp/route_guide/RouteGuide/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/route_guide/RouteGuide/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -110,8 +110,8 @@ Next we need to generate the gRPC client and server interfaces from our .proto s
 If you want to run this yourself, make sure you've installed protoc and gRPC C# plugin. The instructions vary based on your OS:
 
 - For Windows, the `Grpc.Tools` NuGet package contains the binaries you will need to generate the code.
-- For Linux, make sure you've [installed gRPC C Core using Linuxbrew](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/src/csharp#usage-linux-mono)
-- For MacOS, make sure you've [installed gRPC C Core using Homebrew](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/src/csharp#usage-macos-mono)
+- For Linux, make sure you've [installed gRPC C Core using Linuxbrew](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-linux-mono)
+- For MacOS, make sure you've [installed gRPC C Core using Homebrew](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/src/csharp#usage-macos-mono)
 
 Once that's done, you can generate the C# code:
 
@@ -146,7 +146,7 @@ There are two parts to making our `RouteGuide` service do its job:
 - Implementing the service interface generated from our service definition: doing the actual "work" of our service.
 - Running a gRPC server to listen for requests from clients and return the service responses.
 
-You can find our example `RouteGuide` server in [examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/csharp/route_guide/RouteGuideServer/RouteGuideServerImpl.cs). Let's take a closer look at how it works.
+You can find our example `RouteGuide` server in [examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/route_guide/RouteGuideServer/RouteGuideServerImpl.cs). Let's take a closer look at how it works.
 
 ### Implementing RouteGuide
 
@@ -307,7 +307,7 @@ As you can see, we build and start our server using `Grpc.Core.Server` class. To
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating a C# client for our `RouteGuide` service. You can see our complete example client code in [examples/csharp/route_guide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/csharp/route_guide/RouteGuideClient/Program.cs).
+In this section, we'll look at creating a C# client for our `RouteGuide` service. You can see our complete example client code in [examples/csharp/route_guide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/csharp/route_guide/RouteGuideClient/Program.cs).
 
 ### Creating a stub
 

--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -26,7 +26,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/node/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/node/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/node/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/node/route_guide). To download the example, clone the `grpc` repository by running the following command:
 
 ```
 $ git clone https://github.com/grpc/grpc.git
@@ -43,7 +43,7 @@ You also should have the relevant tools installed to generate the server and cli
 
 ## Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -126,7 +126,7 @@ There are two parts to making our `RouteGuide` service do its job:
 - Implementing the service interface generated from our service definition: doing the actual "work" of our service.
 - Running a gRPC server to listen for requests from clients and return the service responses.
 
-You can find our example `RouteGuide` server in [examples/node/route_guide/route_guide_server.js](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/node/route_guide/route_guide_server.js). Let's take a closer look at how it works.
+You can find our example `RouteGuide` server in [examples/node/route_guide/route_guide_server.js](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/node/route_guide/route_guide_server.js). Let's take a closer look at how it works.
 
 ### Implementing RouteGuide
 
@@ -260,7 +260,7 @@ As you can see, we build and start our server with the following steps:
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating a Node.js client for our `RouteGuide` service. You can see our complete example client code in [examples/node/route_guide/route_guide_client.js](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/node/route_guide/route_guide_client.js).
+In this section, we'll look at creating a Node.js client for our `RouteGuide` service. You can see our complete example client code in [examples/node/route_guide/route_guide_client.js](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/node/route_guide/route_guide_client.js).
 
 ### Creating a stub
 

--- a/docs/tutorials/basic/objective-c.md
+++ b/docs/tutorials/basic/objective-c.md
@@ -28,7 +28,7 @@ gRPC and proto3 are specially suited for mobile clients: gRPC is implemented on 
 <a name="setup"></a>
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/objective-c/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/objective-c/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/objective-c/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/objective-c/route_guide). To download the example, clone the `grpc` repository by running the following command:
 
 ```
 $ git clone https://github.com/grpc/grpc.git
@@ -73,7 +73,7 @@ The next sections guide you step-by-step through how this proto service is defin
 <a name="proto"></a>
 ## Defining the service
 
-First let's look at how the service we're using is defined. A gRPC *service* and its method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file for our example in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+First let's look at how the service we're using is defined. A gRPC *service* and its method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file for our example in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -143,7 +143,7 @@ option objc_class_prefix = "RTG";
 
 Next we need to generate the gRPC client interfaces from our .proto service definition. We do this using the protocol buffer compiler (`protoc`) with a special gRPC Objective-C plugin.
 
-For simplicity, we've provided a [Podspec file](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/objective-c/route_guide/RouteGuide.podspec) that runs `protoc` for you with the appropriate plugin, input, and output, and describes how to compile the generated files. You just need to run in this directory (`examples/objective-c/route_guide`):
+For simplicity, we've provided a [Podspec file](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/objective-c/route_guide/RouteGuide.podspec) that runs `protoc` for you with the appropriate plugin, input, and output, and describes how to compile the generated files. You just need to run in this directory (`examples/objective-c/route_guide`):
 
 ```
 $ pod install
@@ -173,7 +173,7 @@ You can also use the provided Podspec file to generate client code from any othe
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating an Objective-C client for our `RouteGuide` service. You can see our complete example client code in [examples/objective-c/route_guide/ViewControllers.m](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/objective-c/route_guide/ViewControllers.m). (Note: In your apps, for maintainability and readability reasons, you shouldn't put all of your view controllers in a single file; it's done here only to simplify the learning process).
+In this section, we'll look at creating an Objective-C client for our `RouteGuide` service. You can see our complete example client code in [examples/objective-c/route_guide/ViewControllers.m](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/objective-c/route_guide/ViewControllers.m). (Note: In your apps, for maintainability and readability reasons, you shouldn't put all of your view controllers in a single file; it's done here only to simplify the learning process).
 
 ### Constructing a client object
 

--- a/docs/tutorials/basic/php.md
+++ b/docs/tutorials/basic/php.md
@@ -28,7 +28,7 @@ With gRPC you can define your service once in a .proto file and implement client
 <a name="setup"></a>
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/php/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/php/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/php/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/php/route_guide). To download the example, clone the `grpc` repository by running the following command:
 
 ```
 $ git clone https://github.com/grpc/grpc.git
@@ -69,7 +69,7 @@ The next sections guide you step-by-step through how this proto service is defin
 <a name="proto"></a>
 ## Defining the service
 
-First let's look at how the service we're using is defined. A gRPC *service* and its method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file for our example in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+First let's look at how the service we're using is defined. A gRPC *service* and its method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file for our example in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -166,7 +166,7 @@ The file contains:
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating a PHP client for our `RouteGuide` service. You can see our complete example client code in [examples/php/route_guide/route_guide_client.php](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/php/route_guide/route_guide_client.php).
+In this section, we'll look at creating a PHP client for our `RouteGuide` service. You can see our complete example client code in [examples/php/route_guide/route_guide_client.php](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/php/route_guide/route_guide_client.php).
 
 ### Constructing a client object
 

--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -27,7 +27,7 @@ With gRPC you can define your service once in a .proto file and implement client
 
 ## Example code and setup
 
-The example code for this tutorial is in [grpc/grpc/examples/python/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/python/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for this tutorial is in [grpc/grpc/examples/python/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/python/route_guide). To download the example, clone the `grpc` repository by running the following command:
 
 ```
 $ git clone https://github.com/grpc/grpc.git
@@ -43,7 +43,7 @@ You also should have the relevant tools installed to generate the server and cli
 
 ## Defining the service
 
-Your first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+Your first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -104,7 +104,7 @@ message Point {
 
 ## Generating client and server code
 
-Next you need to generate the gRPC client and server interfaces from your .proto service definition. You do this using the protocol buffer compiler `protoc` with a special gRPC Python plugin. Make sure you've installed protoc and followed the gRPC Python plugin [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/INSTALL) first):
+Next you need to generate the gRPC client and server interfaces from your .proto service definition. You do this using the protocol buffer compiler `protoc` with a special gRPC Python plugin. Make sure you've installed protoc and followed the gRPC Python plugin [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/INSTALL) first):
 
 With `protoc` and the gRPC Python plugin installed, use the following command to generate the Python code:
 
@@ -132,7 +132,7 @@ Creating and running a `RouteGuide` server breaks down into two work items:
 - Implementing the servicer interface generated from our service definition with functions that perform the actual "work" of the service.
 - Running a gRPC server to listen for requests from clients and transmit responses.
 
-You can find the example `RouteGuide` server in [examples/python/route_guide/route_guide_server.py](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/python/route_guide/route_guide_server.py).
+You can find the example `RouteGuide` server in [examples/python/route_guide/route_guide_server.py](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/route_guide/route_guide_server.py).
 
 ### Implementing RouteGuide
 
@@ -239,7 +239,7 @@ Because `start()` does not block you may need to sleep-loop if there is nothing 
 <a name="client"></a>
 ## Creating the client
 
-You can see the complete example client code in [examples/python/route_guide/route_guide_client.py](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/python/route_guide/route_guide_client.py).
+You can see the complete example client code in [examples/python/route_guide/route_guide_client.py](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/route_guide/route_guide_client.py).
 
 ### Creating a stub
 

--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -27,7 +27,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 
 ## Example code and setup
 
-The example code for our tutorial is in [grpc/grpc/examples/ruby/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.branch }}/examples/ruby/route_guide). To download the example, clone the `grpc` repository by running the following command:
+The example code for our tutorial is in [grpc/grpc/examples/ruby/route_guide](https://github.com/grpc/grpc/tree/{{ site.data.config.grpc_release_branch }}/examples/ruby/route_guide). To download the example, clone the `grpc` repository by running the following command:
 
 ```
 $ git clone https://github.com/grpc/grpc.git
@@ -44,7 +44,7 @@ You also should have the relevant tools installed to generate the server and cli
 
 ## Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/protos/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 
@@ -106,7 +106,7 @@ message Point {
 
 Next we need to generate the gRPC client and server interfaces from our .proto service definition. We do this using the protocol buffer compiler `protoc` with a special gRPC Ruby plugin.
 
-If you want to run this yourself, make sure you've installed protoc and followed the gRPC Ruby plugin [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/INSTALL) first):
+If you want to run this yourself, make sure you've installed protoc and followed the gRPC Ruby plugin [installation instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/INSTALL) first):
 
 Once that's done, the following command can be used to generate the ruby code.
 
@@ -132,7 +132,7 @@ There are two parts to making our `RouteGuide` service do its job:
 - Implementing the service interface generated from our service definition: doing the actual "work" of our service.
 - Running a gRPC server to listen for requests from clients and return the service responses.
 
-You can find our example `RouteGuide` server in [examples/ruby/route_guide/route_guide_server.rb](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/ruby/route_guide/route_guide_server.rb). Let's take a closer look at how it works.
+You can find our example `RouteGuide` server in [examples/ruby/route_guide/route_guide_server.rb](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/ruby/route_guide/route_guide_server.rb). Let's take a closer look at how it works.
 
 ### Implementing RouteGuide
 
@@ -215,7 +215,7 @@ As you can see, we build and start our server using a `GRPC::RpcServer`. To do t
 <a name="client"></a>
 ## Creating the client
 
-In this section, we'll look at creating a Ruby client for our `RouteGuide` service. You can see our complete example client code in [examples/ruby/route_guide/route_guide_client.rb](https://github.com/grpc/grpc/blob/{{ site.data.config.branch }}/examples/ruby/route_guide/route_guide_client.rb).
+In this section, we'll look at creating a Ruby client for our `RouteGuide` service. You can see our complete example client code in [examples/ruby/route_guide/route_guide_client.rb](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/ruby/route_guide/route_guide_client.rb).
 
 ### Creating a stub
 


### PR DESCRIPTION
- A proof of concept - we can now re-factor pieces of data out into yml data file
- Added a `config.yml` in the `_data` folder. Right now it only contains `branch: release-0_10`. We can then access the data via a variable like `{{ site.data.config.branch }}`.
- This allows us to replace all the links currently pointing to the `grpc` repo to point to a specific branch, which we can easily switch out later.
