### PR TITLE
Updates ruby routeguide sample to reflect Beta API changes

### DIFF
--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -200,10 +200,10 @@ Once we've implemented all our methods, we also need to start up a gRPC server s
 
 ```ruby
   s = GRPC::RpcServer.new
-  s.add_http2_port(port)
+  s.add_http2_port(port, :this_port_is_insecure)
   logger.info("... running insecurely on #{port}")
   s.handle(ServerImpl.new(feature_db))
-  s.run
+  s.run_till_terminated
 ```
 As you can see, we build and start our server using a `GRPC::RpcServer`. To do this, we:
 
@@ -300,4 +300,3 @@ Run the client (in a different terminal):
 $ # from examples/ruby
 $ bundle exec route_guide/route_guide_client.rb ../node/route_guide/route_guide_db.json &
 ```
-


### PR DESCRIPTION
- updates the sample code to reflect changes in the beta api

Note that
- No link changes are necessary, these are all handled in #66 (or should be)
- changes in the PR can be viewed locally by [running jekyll](http://michaelchelen.net/81fa/install-jekyll-2-ubuntu-14-04/)

This changes follows-up on the quick start docs changes made in grpc/grpc#3442
