### PR TITLE
Add link to generated go docs

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -48,6 +48,7 @@ icon: <i class="fa fa-book"></i>
       <li><a target="_blank" href="http://www.grpc.io/grpc/node/">Node.js API</a></li>
       <li><a target="_blank" href="http://www.grpc.io/grpc/csharp/">C# API</a></li>
       <li><a target="_blank" href="http://www.grpc.io/grpc/php/namespaces/Grpc.html">PHP API</a></li>
+      <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">Go API</a></li>
       <li><h5>Other Reference</h5><ul>
       <li><a target="_blank" href="http://www.grpc.io/grpc/core/">gRPC Core</a></ul></li>
       </ul></li>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc.github.io/issues/121
