### PR TITLE
Update C# docs for the new auth API.

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -173,13 +173,15 @@ var scope = 'https://www.googleapis.com/auth/grpc-testing';
 
 ###Authenticating with Google (C#)
 
+**Base case - No encryption/authentication**
 ```csharp
-// Base case - No encryption/authentication
 var channel = new Channel("localhost:50051", ChannelCredentials.Insecure);
 var client = new Greeter.GreeterClient(channel);
 ...
+```
 
-// Authenticating with Google (recommended approach using JWT access token)
+**Authenticating with Google (recommended approach using JWT access token)**
+```csharp
 using Grpc.Auth;  // from Grpc.Auth NuGet package
 ...
 // Loads Google Application Default Credentials with publicly trusted roots.
@@ -188,8 +190,10 @@ var channelCredentials = await GoogleGrpcCredentials.GetApplicationDefaultAsync(
 var channel = new Channel("greeter.googleapis.com", channelCredentials);
 var client = new Greeter.GreeterClient(channel);
 ...
+```
 
-// Authenticating with Google (legacy approach using OAuth2)
+**Authenticating with Google (legacy approach using OAuth2)**
+```csharp
 using Grpc.Auth;  // from Grpc.Auth NuGet package
 ...
 string scope = "https://www.googleapis.com/auth/grpc-testing";
@@ -201,8 +205,10 @@ if (googleCredential.IsCreateScopedRequired)
 var channel = new Channel("greeter.googleapis.com", googleCredential.ToChannelCredentials());
 var client = new Greeter.GreeterClient(channel);
 ...
+```
 
-// Authenticating a single RPC call with Google
+**Authenticating a single RPC call with Google**
+```csharp
 var channel = new Channel("greeter.googleapis.com", new SslCredentials());  // Use publicly trusted roots.
 var client = new Greeter.GreeterClient(channel);
 ...

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -127,8 +127,8 @@ var client = new Greeter.GreeterClient(channel);
 ...
 
 // With server authentication SSL/TLS
-var channelCredentials = new SslCredentials(File.ReadAllText("ca.pem"));  // Load a CA file
-var channel = new Channel("localhost:50051", channelCredentials);
+var channelCredentials = new SslCredentials(File.ReadAllText("roots.pem"));  // Load a CA file
+var channel = new Channel("myservice.example.com", channelCredentials);
 var client = new Greeter.GreeterClient(channel);
 ```
 

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -127,7 +127,7 @@ var client = new Greeter.GreeterClient(channel);
 ...
 
 // With server authentication SSL/TLS
-var channelCredentials = new SslCredentials(File.ReadAllText("roots.pem"));  // Load a CA file
+var channelCredentials = new SslCredentials(File.ReadAllText("roots.pem"));  // Load a custom roots file.
 var channel = new Channel("myservice.example.com", channelCredentials);
 var client = new Greeter.GreeterClient(channel);
 ```

--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -180,7 +180,7 @@ var client = new Greeter.GreeterClient(channel);
 ...
 ```
 
-**Authenticating with Google (recommended approach using JWT access token)**
+**Authenticate using JWT access token (recommended approach)**
 ```csharp
 using Grpc.Auth;  // from Grpc.Auth NuGet package
 ...
@@ -192,7 +192,7 @@ var client = new Greeter.GreeterClient(channel);
 ...
 ```
 
-**Authenticating with Google (legacy approach using OAuth2)**
+**Authenticate using OAuth2 token (legacy approach)**
 ```csharp
 using Grpc.Auth;  // from Grpc.Auth NuGet package
 ...
@@ -207,7 +207,7 @@ var client = new Greeter.GreeterClient(channel);
 ...
 ```
 
-**Authenticating a single RPC call with Google**
+**Authenticate a single RPC call**
 ```csharp
 var channel = new Channel("greeter.googleapis.com", new SslCredentials());  // Use publicly trusted roots.
 var client = new Greeter.GreeterClient(channel);

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -297,8 +297,8 @@ To call service methods, we first need to create a *stub*.
 First, we need to create a gRPC client channel that will connect to gRPC server. Then, we use the `RouteGuide.NewClient` method of the `RouteGuide` class generated from our .proto.
 
 ```csharp
-Channel channel = new Channel("127.0.0.1:50052", Credentials.Insecure)
-var client = new RouteGuideClient(RouteGuide.NewClient(channel));
+Channel channel = new Channel("127.0.0.1:50052", ChannelCredentials.Insecure)
+var client = RouteGuide.NewClient(channel);
 
 // YOUR CODE GOES HERE
 


### PR DESCRIPTION
Update C# to the new auth API coming in 0.12 release.
This should be enough to address C# portion of https://github.com/grpc/grpc/issues/4243.

@jboeuf  for sanity check. Besides JWT, I decided to cover also OAuth2 and  per-rpc cases, because they might come handy.