### PR TITLE
Remove version specifier from Ruby reference docs link

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -11,7 +11,7 @@ title: Reference
   <li><a target="_blank" href="http://www.grpc.io/grpc/cpp/index.html">C++ API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc-java/javadoc/index.html">Java API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/python/">Python API</a></li>
-  <li><a target="_blank" href="http://www.rubydoc.info/gems/grpc/0.11.0">Ruby API</a></li>
+  <li><a target="_blank" href="http://www.rubydoc.info/gems/grpc">Ruby API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/node/">Node.js API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/csharp/">C# API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/php/namespaces/Grpc.html">PHP API</a></li>


### PR DESCRIPTION
By default, if no version is given, the link will go to the latest published version, which is what we always want.