### PR TITLE
Fix link to Design Motivations & Principles

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ service HelloService {
     </p>
     <h3>Why gRPC?</h3>
     <p>
-      Read the <a href="/posts/principles/">Design Motivations &amp; Principles</a> behind gRPC.
+      Read the <a href="/posts/principles">Design Motivations &amp; Principles</a> behind gRPC.
     </p>
   </div>
 </div>


### PR DESCRIPTION
The link currently points to [/posts/principles/](http://www.grpc.io/posts/principles/) which returns returns 404
The correct link seems to be [/posts/principles](http://www.grpc.io/posts/principles) (no trailing slash).