### PR TITLE
Fixed wrong link

### DIFF
--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -42,7 +42,7 @@ You also should have the relevant tools installed to generate the server and cli
 
 ## Defining the service
 
-Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/helloworld/proto/route_guide.proto`](https://github.com/grpc/grpc-go/blob/master/examples/helloworld/proto/route_guide.proto).
+Our first step (as you'll know from the [Overview](/docs/index.html)) is to define the gRPC *service* and the method *request* and *response* types using [protocol buffers] (https://developers.google.com/protocol-buffers/docs/overview). You can see the complete .proto file in [`examples/route_guide/routeguide/route_guide.proto`](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/routeguide/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:
 


### PR DESCRIPTION
I corrected a link in the [basic tutorial for go](http://www.grpc.io/docs/tutorials/basic/go.html#defining-the-service). 

The old link https://github.com/grpc/grpc-go/blob/master/examples/helloworld/proto/route_guide.proto resulted in a 404 error.