### PR TITLE
Fix C# non-Windows `protoc` plugin argument

### DIFF
--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -125,7 +125,7 @@ Normally you would need to add the `Grpc.Tools` package to the solution yourself
 - On Linux or OS X, we rely on `protoc` and `grpc_csharp_plugin` being installed by Linuxbrew/Homebrew. Run this command from the route_guide directory:
 
   ```
-  $ protoc -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide --plugin=`which grpc_csharp_plugin` ../../protos/route_guide.proto
+  $ protoc -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide --plugin=protoc-gen-grpc=`which grpc_csharp_plugin` ../../protos/route_guide.proto
   ```
 
 Running the appropriate command for your OS regenerates the following files in the RouteGuide directory:


### PR DESCRIPTION
Trying to do this myself it failed. I noticed that the Windows command included the plugin name before the location of the plugin executable.