### PR TITLE
Fixing broken Quick start link

### DIFF
--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -39,7 +39,7 @@ Then change your current directory to `examples/python/route_guide`:
 $ cd examples/python/route_guide
 ```
 
-You also should have the relevant tools installed to generate the server and client interface code - if you don't already, follow the setup instructions in [the Python quick start guide](/docs/installation/python.html).
+You also should have the relevant tools installed to generate the server and client interface code - if you don't already, follow the setup instructions in [the Python quick start guide](https://github.com/grpc/grpc/tree/master/examples/python).
 
 ## Defining the service
 


### PR DESCRIPTION
Hey 👋 

I was going through the gRPC Basics - Python tutorial and noticed that the link for setup instruction in the quickstart guide was pointing to http://www.grpc.io/docs/installation/python.html which doesn't seem to exist.

I've changed this to point to https://github.com/grpc/grpc/tree/master/examples/python which I believe to contain the intended information?

Thanks,
.FxN