### PR TITLE
tutorial/java: Call bindService

### DIFF
--- a/docs/tutorials/basic/java.md
+++ b/docs/tutorials/basic/java.md
@@ -329,7 +329,7 @@ Once we've implemented all our methods, we also need to start up a gRPC server s
   /** Create a RouteGuide server using serverBuilder as a base and features as data. */
   public RouteGuideServer(ServerBuilder<?> serverBuilder, int port, Collection<Feature> features) {
     this.port = port;
-    server = serverBuilder.addService(new RouteGuideService(features))
+    server = serverBuilder.addService(RouteGuideGrpc.bindService(new RouteGuideService(features)))
         .build();
   }
   ...


### PR DESCRIPTION
This fixes an inconsistency (caused by me) due to half-updating the docs
in commit 9368475.

bindService is not necessary when extending AbstractRouteGuide instead
of implementing RouteGuide. Using AbstractRouteGuide is becoming the
preferred method, but for now we just want fix the current method.

Fixes grpc/grpc-java#1850