### PR TITLE
Google authentication cleanup.

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -169,26 +169,13 @@ creds = GRPC::Core::Credentials.new(load_certs)  # load_certs typically loads a 
 stub = Helloworld::Greeter::Stub.new('myservice.example.com', creds)
 ```
 
-#### Authenticate with Google using scopeless credentials (recommended approach)
+#### Authenticate with Google
 
 ```ruby
 require 'googleauth'  # from http://www.rubydoc.info/gems/googleauth/0.1.0
 ...
 ssl_creds = GRPC::Core::ChannelCredentials.new(load_certs)  # load_certs typically loads a CA roots file
 authentication = Google::Auth.get_application_default()
-call_creds = GRPC::Core::CallCredentials.new(authentication.updater_proc)
-combined_creds = ssl_creds.compose(call_creds)
-stub = Helloworld::Greeter::Stub.new('greeter.googleapis.com', combined_creds)
-```
-
-#### Authenticate with Google using Oauth2 token (legacy approach)
-
-```ruby
-require 'googleauth'  # from http://www.rubydoc.info/gems/googleauth/0.1.0
-...
-ssl_creds = GRPC::Core::ChannelCredentials.new(load_certs)  # load_certs typically loads a CA roots file
-scope = 'https://www.googleapis.com/auth/grpc-testing'
-authentication = Google::Auth.get_application_default(scope)
 call_creds = GRPC::Core::CallCredentials.new(authentication.updater_proc)
 combined_creds = ssl_creds.compose(call_creds)
 stub = Helloworld::Greeter::Stub.new('greeter.googleapis.com', combined_creds)
@@ -212,7 +199,7 @@ std::unique_ptr<Greeter::Stub> stub(Greeter::NewStub(channel));
 ...
 ```
 
-#### Authenticate with Google using scopeless credentials
+#### Authenticate with Google
 
 ```cpp
 auto creds = grpc::GoogleDefaultCredentials();
@@ -239,7 +226,7 @@ var channel = new Channel("myservice.example.com", channelCredentials);
 var client = new Greeter.GreeterClient(channel);
 ```
 
-####Authenticate with Google using scopeless credentials (recommended approach)
+####Authenticate with Google
 ```csharp
 using Grpc.Auth;  // from Grpc.Auth NuGet package
 ...
@@ -247,21 +234,6 @@ using Grpc.Auth;  // from Grpc.Auth NuGet package
 var channelCredentials = await GoogleGrpcCredentials.GetApplicationDefaultAsync();
 
 var channel = new Channel("greeter.googleapis.com", channelCredentials);
-var client = new Greeter.GreeterClient(channel);
-...
-```
-
-####Authenticate with Google using OAuth2 token (legacy approach)
-```csharp
-using Grpc.Auth;  // from Grpc.Auth NuGet package
-...
-string scope = "https://www.googleapis.com/auth/grpc-testing";
-var googleCredential = await GoogleCredential.GetApplicationDefaultAsync();
-if (googleCredential.IsCreateScopedRequired)
-{
-    googleCredential = googleCredential.CreateScoped(new[] { scope });
-}
-var channel = new Channel("greeter.googleapis.com", googleCredential.ToChannelCredentials());
 var client = new Greeter.GreeterClient(channel);
 ...
 ```
@@ -300,7 +272,7 @@ channel = implementations.secure_channel('myservice.example.com', 443, creds)
 stub = helloworld_pb2.beta_create_Greeter_stub(channel)
 ```
 
-####Authenticate with Google using OAuth2 token (legacy approach)
+####Authenticate with Google
 ```python
 transport_creds = implementations.ssl_channel_credentials(open('roots.pem').read(), None, None)
 def oauth2token_credentials(context, callback):
@@ -363,7 +335,7 @@ ManagedChannel channel = NettyChannelBuilder.forAddress("myservice.example.com",
 GreeterGrpc.GreeterStub stub = GreeterGrpc.newStub(channel);
 ```
 
-####Authenticate with Google using OAuth2 token
+####Authenticate with Google
 
 The following code snippet shows how you can call the [Google Cloud PubSub API](https://cloud.google.com/pubsub/overview) using gRPC with a service account. The credentials are loaded from a key stored in a well-known location or by detecting that the application is running in an environment that can provide one automatically, e.g. Google Compute Engine. While this example is specific to Google and its services, similar patterns can be followed for other service providers.
 
@@ -398,7 +370,7 @@ var ssl_creds = grpc.credentials.createSsl(root_certs);
 var stub = new helloworld.Greeter('myservice.example.com', ssl_creds);
 ```
 
-####Authenticate with Google using scopeless credentials (recommended approach)
+####Authenticate with Google
 
 ```js
 // Authenticating with Google
@@ -412,24 +384,6 @@ var ssl_creds = grpc.credentials.createSsl(root_certs);
 });
 ```
 
-####Authenticate with Google using Oauth2 token (legacy approach)
-
-```js
-var GoogleAuth = require('google-auth-library'); // from https://www.npmjs.com/package/google-auth-library
-...
-var ssl_creds = grpc.Credentials.createSsl(root_certs); // load_certs typically loads a CA roots file
-var scope = 'https://www.googleapis.com/auth/grpc-testing';
-(new GoogleAuth()).getApplicationDefault(function(err, auth) {
-  if (auth.createScopeRequired()) {
-    auth = auth.createScoped(scope);
-  }
-  var call_creds = grpc.credentials.createFromGoogleCredential(auth);
-  var combined_creds = grpc.credentials.combineChannelCredentials(ssl_creds, call_creds);
-  var stub = new helloworld.Greeter('greeter.googleapis.com', combined_credentials);
-});
-```
-
-
 ### PHP
 
 ####Base case - No encryption/authorization
@@ -441,7 +395,7 @@ $client = new helloworld\GreeterClient('localhost:50051', [
 ...
 ```
 
-####Authenticate with Google using scopeless credentials (recommended approach)
+####Authenticate with Google
 
 ```php
 function updateAuthMetadataCallback($context)
@@ -458,16 +412,3 @@ $opts = [
 ];
 $client = new helloworld\GreeterClient('greeter.googleapis.com', $opts);
 ````
-
-####Authenticate with Google using Oauth2 token (legacy approach)
-
-```php
-// the environment variable "GOOGLE_APPLICATION_CREDENTIALS" needs to be set
-$scope = "https://www.googleapis.com/auth/grpc-testing";
-$auth = Google\Auth\ApplicationDefaultCredentials::getCredentials($scope);
-$opts = [
-  'credentials' => Grpc\Credentials::createSsl(file_get_contents('roots.pem'));
-  'update_metadata' => $auth->getUpdateMetadataFunc(),
-];
-$client = new helloworld\GreeterClient('greeter.googleapis.com', $opts);
-```


### PR DESCRIPTION
- Removing legacy way to authenticate with Google.
- Java and Python will need to update their examples to use "scopeless"
  creds.
- Fixes #180.