### PR TITLE
Added "release" URL

### DIFF
--- a/release
+++ b/release
@@ -1,0 +1,5 @@
+---
+permalink: /release
+---
+
+{{ site.data.config.grpc_release_branch }}


### PR DESCRIPTION
In order to get the branch name for the current release. This will be used throughout tutorials and examples where checking out a specific branch is better than working at HEAD. For example

```
$ git clone -b $(curl http://grpc.io/release) github.com/grpc/grpc
```