### PR TITLE
lowercase 'c' in 'credentials' in Node GRPC lib

### DIFF
--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -269,7 +269,7 @@ In this section, we'll look at creating a Node.js client for our `RouteGuide` se
 To call service methods, we first need to create a *stub*. To do this, we just need to call the RouteGuide stub constructor, specifying the server address and port.
 
 ```js
-new example.RouteGuide('localhost:50051', grpc.Credentials.createInsecure());
+new example.RouteGuide('localhost:50051', grpc.credentials.createInsecure());
 ```
 
 ### Calling service methods


### PR DESCRIPTION
# Proof

_index.js_

``` js
const grpc = require('grpc');
console.log(grpc.Credentials);
console.log(grpc.credentials);
```

_..._

``` sh
$ node index.js
undefined
{ createSsl: [Function],
  createFromMetadataGenerator: [Function],
  createFromGoogleCredential: [Function],
  combineChannelCredentials: [Function],
  combineCallCredentials: [Function],
  createInsecure: [Function] }
$ npm ls | grep grpc
├─┬ grpc@0.15.0
```
