### PR TITLE
Remove extraneous anchor tag that breaks rendering

### DIFF
--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -102,7 +102,6 @@ In a bidirectional streaming RPC, again the call is initiated by the client call
 
 What happens next depends on the application, as the client and server can read and write in any order - the streams operate completely independently. So, for example, the server could wait until it has received all the client's messages before writing its responses, or the server and client could "ping-pong": the server gets a request, then sends back a response, then the client sends another request based on the response, and so on.
 
-<a name="deadlines"></a>
 ### Deadlines
 
 gRPC allows clients to specify a deadline value when calling a remote method. This specifies how long the client wants to wait for a response from the server before the RPC finishes with the error `DEADLINE_EXCEEDED`. On the server side, the server can query the deadline to see if a particular method has timed out, or how much time is left to complete the method.


### PR DESCRIPTION
The "Deadlines" header is not rendered correctly on the live [grpc.io site](http://www.grpc.io/docs/guides/concepts.html#deadlines). This is almost certainly due to the manually-inserted anchor tag immediately preceding it.