### PR TITLE
Local build \w bundle: update Gemfile to match latest gh-pages instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 *.swp
 .sass-cache/
 .DS_Store
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'github-pages'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
This is one of the steps in order to get local bundle workflow working:  

```
bundle install --path vendor/bundle
bundle exec jekyll serve --watch
```

This PR syncs content of the Gemfile with latest [github pages instructions](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#step-2-install-jekyll-using-bundler).
