### PR TITLE
Local build \w bundle: update Jekyll config to exclude 'vendor' sub-dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site/
 *.swp
 .sass-cache/
+vendor
 .DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,5 @@ paginate: 2
 paginate_path: "/blog/page:num/"
 
 excerpt_separator: <!--more-->
+
+exclude: [vendor]


### PR DESCRIPTION
This is one of the steps in order to get local bundle workflow working:  

```
bundle install --path vendor/bundle
bundle exec jekyll serve --watch
```

In order to be able to run `bundle install` on local env without sudo,
bundle suggests to install everything under ./vendor/bundle by default.

If not excluded, Jekyll will try to build default posts from it
and fail with:

```
 Generating...
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '0000-00-00': Post '/vendor/bundle/ruby/2.0.0/gems/jekyll-2.4.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the filename.
```

This PR excludes `./vendor` sub dir from the Jekyll build
