### PR TITLE
Fix markdown rendering in Python tutorial

### DIFF
--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -128,7 +128,6 @@ Note that as we've already provided a version of the generated code in the examp
    - `beta_create_RouteGuide_server`, which creates a gRPC server given an `BetaRouteGuideServicer` object
    - `beta_create_RouteGuide_stub`, which can be used by clients to create a stub object
 
-<a name="server"></a>
 ## Creating the server
 
 First let's look at how you create a `RouteGuide` server. If you're only interested in creating gRPC clients, you can skip this section and go straight to [Creating the client](#client) (though you might find it interesting anyway!).
@@ -241,7 +240,6 @@ def serve():
 
 Because `start()` does not block you may need to sleep-loop if there is nothing else for your code to do while serving.
 
-<a name="client"></a>
 ## Creating the client
 
 You can see the complete example client code in [examples/python/route_guide/route_guide_client.py](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_branch }}/examples/python/route_guide/route_guide_client.py).


### PR DESCRIPTION
Remove extra tag from markdown that breaks rendering of Heading 2. 
Same as #248 but for the Python tutorial.

**Before:**
![screen shot 2016-07-29 at 14 39 18](https://cloud.githubusercontent.com/assets/5582506/17238934/fd659fb6-559a-11e6-8c74-67f941f00901.png)


**After:**
![screen shot 2016-07-29 at 14 39 37](https://cloud.githubusercontent.com/assets/5582506/17238937/02f47b78-559b-11e6-9906-697c269559af.png)
