### PR TITLE
Don't line-wrap code snippets

### DIFF
--- a/_sass/base/_override.scss
+++ b/_sass/base/_override.scss
@@ -60,6 +60,14 @@ pre, pre.prettyprint {
   padding: 9.5px !important;
 }
 
+pre code {
+  white-space: pre;
+
+  @media print {
+    white-space: pre-wrap;
+  }
+}
+
 .inverse {
   background-color: $mainBrandColor;
   color: white;

--- a/_sass/pages/_docs.scss
+++ b/_sass/pages/_docs.scss
@@ -4,8 +4,8 @@
   *[id]:before { 
     display: block; 
     content: " "; 
-    margin-top: -61px; 
-    height: 61px; 
+    margin-top: -1em;
+    height: 1em;
     visibility: hidden; 
   }
 


### PR DESCRIPTION
Line-wrapped code looks horrible; just displaying a scroll bar is much
better when possible.

Headers could previously overlap with the scroll bar of code which would
prevent scrolling. This was to create a larger clickable area for
headers. However, the clickable area was much larger than it needed to
be, and simply reducing the area produces apparently-identical results
without breaking scrolling for code snippets.