### PR TITLE
Remove unnecessary indentation in code snippets

### DIFF
--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -21,12 +21,12 @@ type: markdown
 You'll need a local copy of the example code to work through this quickstart. Download the example code from our GitHub repository (the following command clones the entire repository, but you just need the examples for this quickstart and other tutorials):
 
 ```sh
-  $ # Clone the repository to get the example code
-  $ git clone https://github.com/grpc/grpc
-  $ # Navigate to the dynamic codegen "hello, world" Node example:
-  $ cd examples/node/dynamic_codegen
-  $ # Install the example's dependencies
-  $ npm install
+$ # Clone the repository to get the example code
+$ git clone https://github.com/grpc/grpc
+$ # Navigate to the dynamic codegen "hello, world" Node example:
+$ cd examples/node/dynamic_codegen
+$ # Install the example's dependencies
+$ npm install
 ```
 
 ## Run a gRPC application

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -26,7 +26,7 @@ e.g. [Node.js](node-quickstart.md).
 Install gRPC:
 
 ```sh
-  $ [sudo] pecl install grpc
+$ [sudo] pecl install grpc
 ```
 
 ### Install Protobuf-PHP
@@ -42,10 +42,10 @@ tutorials and your own projects.
 To install Protobuf-PHP, run:
 
 ```sh
-  $ git clone https://github.com/stanley-cheung/Protobuf-PHP
-  $ cd Protobuf-PHP
-  $ rake pear:package version=1.0
-  $ [sudo] pear install Protobuf-1.0.tgz
+$ git clone https://github.com/stanley-cheung/Protobuf-PHP
+$ cd Protobuf-PHP
+$ rake pear:package version=1.0
+$ [sudo] pear install Protobuf-1.0.tgz
 ```
 
 ## Download the example
@@ -53,11 +53,11 @@ To install Protobuf-PHP, run:
 You'll need a local copy of the example code to work through this quickstart. Download the example code from our Github repository (the following command clones the entire repository, but you just need the examples for this quickstart and other tutorials):
 
 ```sh
-  $ # Clone the repository to get the example code:
-  $ git clone https://github.com/grpc/grpc
-  $ # Navigate to the "hello, world" PHP example:
-  $ cd grpc/examples/php
-  $ composer install
+$ # Clone the repository to get the example code:
+$ git clone https://github.com/grpc/grpc
+$ # Navigate to the "hello, world" PHP example:
+$ cd grpc/examples/php
+$ composer install
 ```
 
 ## Run a gRPC application

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -20,13 +20,13 @@ type: markdown
 Install gRPC:
 
 ```sh
-  $ pip install grpcio
+$ pip install grpcio
 ```
 
 Or, to install it system wide:
 
 ```sh
-  $ sudo pip install grpcio
+$ sudo pip install grpcio
 ```
 
 If you're on Windows, make sure you installed the `pip.exe` component when you
@@ -34,7 +34,7 @@ installed Python. Invoke as above but with `pip.exe` instead of `pip` (you may
 also need to invoke from a `cmd.exe` run as administrator):
 
 ```sh
-  $ pip.exe install grpcio
+$ pip.exe install grpcio
 ```
 
 ### Install gRPC tools
@@ -58,10 +58,10 @@ pip install grpcio-tools
 You'll need a local copy of the example code to work through this quickstart. Download the example code from our Github repository (the following command clones the entire repository, but you just need the examples for this quickstart and other tutorials):
 
 ```sh
-  $ # Clone the repository to get the example code:
-  $ git clone https://github.com/grpc/grpc
-  $ # Navigate to the "hello, world" Python example:
-  $ cd grpc/examples/python/helloworld
+$ # Clone the repository to get the example code:
+$ git clone https://github.com/grpc/grpc
+$ # Navigate to the "hello, world" Python example:
+$ cd grpc/examples/python/helloworld
 ```
 
 ## Run a gRPC application
@@ -191,7 +191,7 @@ Just like we did before, from the `examples/python/helloworld` directory:
 
    ```sh
    $ python greeter_client.py
-```
+   ```
 
 ## What's next
 

--- a/docs/quickstart/ruby.md
+++ b/docs/quickstart/ruby.md
@@ -19,7 +19,7 @@ type: markdown
 ### Install gRPC
 
 ```
-  $ gem install grpc
+$ gem install grpc
 ```
 
 ### Install gRPC tools
@@ -43,10 +43,10 @@ gem install grpc-tools
 You'll need a local copy of the example code to work through this quickstart. Download the example code from our Github repository (the following command clones the entire repository, but you just need the examples for this quickstart and other tutorials):
 
 ```sh
-  $ # Clone the repository to get the example code:
-  $ git clone https://github.com/grpc/grpc
-  $ # Navigate to the "hello, world" Ruby example:
-  $ cd grpc/examples/ruby
+$ # Clone the repository to get the example code:
+$ git clone https://github.com/grpc/grpc
+$ # Navigate to the "hello, world" Ruby example:
+$ cd grpc/examples/ruby
 ```
 
 ## Run a gRPC application

--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -59,34 +59,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 - A *simple RPC* where the client sends a request to the server using the stub and waits for a response to come back, just like a normal function call.
 
 ```
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *server-side streaming RPC* where the client sends a request to the server and gets a stream to read a sequence of messages back. The client reads from the returned stream until there are no more messages. As you can see in our example, you specify a server-side streaming method by placing the `stream` keyword before the *response* type.
 
 ```
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages and sends them to the server, again using a provided stream. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a client-side streaming method by placing the `stream` keyword before the *request* type.
 
 ```
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages using a read-write stream. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -159,12 +159,12 @@ In this case we're implementing the *synchronous* version of `RouteGuide`, which
 `RouteGuideImpl` implements all our service methods. Let's look at the simplest type first, `GetFeature`, which just gets a `Point` from the client and returns the corresponding feature information from its database in a `Feature`.
 
 ```cpp
-  Status GetFeature(ServerContext* context, const Point* point,
-                    Feature* feature) override {
-    feature->set_name(GetFeatureName(*point, feature_list_));
-    feature->mutable_location()->CopyFrom(*point);
-    return Status::OK;
-  }
+Status GetFeature(ServerContext* context, const Point* point,
+                  Feature* feature) override {
+  feature->set_name(GetFeatureName(*point, feature_list_));
+  feature->mutable_location()->CopyFrom(*point);
+  return Status::OK;
+}
 ```
 
 The method is passed a context object for the RPC, the client's `Point` protocol buffer request, and a `Feature` protocol buffer to fill in with the response information. In the method we populate the `Feature` with the appropriate information, and then `return` with an `OK` status to tell gRPC that we've finished dealing with the RPC and that the `Feature` can be returned to the client.
@@ -172,24 +172,24 @@ The method is passed a context object for the RPC, the client's `Point` protocol
 Now let's look at something a bit more complicated - a streaming RPC. `ListFeatures` is a server-side streaming RPC, so we need to send back multiple `Feature`s to our client.
 
 ```cpp
-  Status ListFeatures(ServerContext* context, const Rectangle* rectangle,
-                      ServerWriter<Feature>* writer) override {
-    auto lo = rectangle->lo();
-    auto hi = rectangle->hi();
-    long left = std::min(lo.longitude(), hi.longitude());
-    long right = std::max(lo.longitude(), hi.longitude());
-    long top = std::max(lo.latitude(), hi.latitude());
-    long bottom = std::min(lo.latitude(), hi.latitude());
-    for (const Feature& f : feature_list_) {
-      if (f.location().longitude() >= left &&
-          f.location().longitude() <= right &&
-          f.location().latitude() >= bottom &&
-          f.location().latitude() <= top) {
-        writer->Write(f);
-      }
+Status ListFeatures(ServerContext* context, const Rectangle* rectangle,
+                    ServerWriter<Feature>* writer) override {
+  auto lo = rectangle->lo();
+  auto hi = rectangle->hi();
+  long left = std::min(lo.longitude(), hi.longitude());
+  long right = std::max(lo.longitude(), hi.longitude());
+  long top = std::max(lo.latitude(), hi.latitude());
+  long bottom = std::min(lo.latitude(), hi.latitude());
+  for (const Feature& f : feature_list_) {
+    if (f.location().longitude() >= left &&
+        f.location().longitude() <= right &&
+        f.location().latitude() >= bottom &&
+        f.location().latitude() <= top) {
+      writer->Write(f);
     }
-    return Status::OK;
   }
+  return Status::OK;
+}
 ```
 
 As you can see, instead of getting simple request and response objects in our method parameters, this time we get a request object (the `Rectangle` in which our client wants to find `Feature`s) and a special `ServerWriter` object. In the method, we populate as many `Feature` objects as we need to return, writing them to the `ServerWriter` using its `Write()` method. Finally, as in our simple RPC, we `return Status::OK` to tell gRPC that we've finished writing responses.
@@ -204,22 +204,22 @@ while (stream->Read(&point)) {
 Finally, let's look at our bidirectional streaming RPC `RouteChat()`.
 
 ```cpp
-  Status RouteChat(ServerContext* context,
-                   ServerReaderWriter<RouteNote, RouteNote>* stream) override {
-    std::vector<RouteNote> received_notes;
-    RouteNote note;
-    while (stream->Read(&note)) {
-      for (const RouteNote& n : received_notes) {
-        if (n.location().latitude() == note.location().latitude() &&
-            n.location().longitude() == note.location().longitude()) {
-          stream->Write(n);
-        }
+Status RouteChat(ServerContext* context,
+                 ServerReaderWriter<RouteNote, RouteNote>* stream) override {
+  std::vector<RouteNote> received_notes;
+  RouteNote note;
+  while (stream->Read(&note)) {
+    for (const RouteNote& n : received_notes) {
+      if (n.location().latitude() == note.location().latitude() &&
+          n.location().longitude() == note.location().longitude()) {
+        stream->Write(n);
       }
-      received_notes.push_back(note);
     }
-
-    return Status::OK;
+    received_notes.push_back(note);
   }
+
+  return Status::OK;
+}
 ```
 
 This time we get a `ServerReaderWriter` that can be used to read *and* write messages. The syntax for reading and writing here is exactly the same as for our client-streaming and server-streaming methods. Although each side will always get the other's messages in the order they were written, both the client and server can read and write in any order — the streams operate completely independently.
@@ -269,12 +269,12 @@ grpc::CreateChannel("localhost:50051", grpc::InsecureCredentials(), ChannelArgum
 Now we can use the channel to create our stub using the `NewStub` method provided in the `RouteGuide` class we generated from our .proto.
 
 ```cpp
- public:
-  RouteGuideClient(std::shared_ptr<ChannelInterface> channel,
-                   const std::string& db)
-      : stub_(RouteGuide::NewStub(channel)) {
-    ...
-  }
+public:
+ RouteGuideClient(std::shared_ptr<ChannelInterface> channel,
+                  const std::string& db)
+     : stub_(RouteGuide::NewStub(channel)) {
+   ...
+ }
 ```
 
 ### Calling service methods
@@ -286,26 +286,26 @@ Now let's look at how we call our service methods. Note that in this tutorial we
 Calling the simple RPC `GetFeature` is nearly as straightforward as calling a local method.
 
 ```cpp
-  Point point;
-  Feature feature;
-  point = MakePoint(409146138, -746188906);
-  GetOneFeature(point, &feature);
+Point point;
+Feature feature;
+point = MakePoint(409146138, -746188906);
+GetOneFeature(point, &feature);
 
 ...
 
-  bool GetOneFeature(const Point& point, Feature* feature) {
-    ClientContext context;
-    Status status = stub_->GetFeature(&context, point, feature);
-    ...
-  }
+bool GetOneFeature(const Point& point, Feature* feature) {
+  ClientContext context;
+  Status status = stub_->GetFeature(&context, point, feature);
+  ...
+}
 ```
 
 As you can see, we create and populate a request protocol buffer object (in our case `Point`), and create a response protocol buffer object for the server to fill in. We also create a `ClientContext` object for our call - you can optionally set RPC configuration values on this object, such as deadlines, though for now we'll use the default settings. Note that you cannot reuse this object between calls. Finally, we call the method on the stub, passing it the context, request, and response. If the method returns `OK`, then we can read the response information from the server from our response object.
 
 ```cpp
-      std::cout << "Found feature called " << feature->name()  << " at "
-                << feature->location().latitude()/kCoordFactor_ << ", "
-                << feature->location().longitude()/kCoordFactor_ << std::endl;
+std::cout << "Found feature called " << feature->name()  << " at "
+          << feature->location().latitude()/kCoordFactor_ << ", "
+          << feature->location().longitude()/kCoordFactor_ << std::endl;
 ```
 
 #### Streaming RPCs
@@ -313,15 +313,15 @@ As you can see, we create and populate a request protocol buffer object (in our 
 Now let's look at our streaming methods. If you've already read [Creating the server](#server) some of this may look very familiar - streaming RPCs are implemented in a similar way on both sides. Here's where we call the server-side streaming method `ListFeatures`, which returns a stream of geographical `Feature`s:
 
 ```cpp
-    std::unique_ptr<ClientReader<Feature> > reader(
-        stub_->ListFeatures(&context, rect));
-    while (reader->Read(&feature)) {
-      std::cout << "Found feature called "
-                << feature.name() << " at "
-                << feature.location().latitude()/kCoordFactor_ << ", "
-                << feature.location().longitude()/kCoordFactor_ << std::endl;
-    }
-    Status status = reader->Finish();
+std::unique_ptr<ClientReader<Feature> > reader(
+    stub_->ListFeatures(&context, rect));
+while (reader->Read(&feature)) {
+  std::cout << "Found feature called "
+            << feature.name() << " at "
+            << feature.location().latitude()/kCoordFactor_ << ", "
+            << feature.location().longitude()/kCoordFactor_ << std::endl;
+}
+Status status = reader->Finish();
 ```
 
 Instead of passing the method a context, request, and response, we pass it a context and request and get a `ClientReader` object back. The client can use the `ClientReader` to read the server's responses. We use the `ClientReader`s `Read()` method to repeatedly read in the server's responses to a response protocol buffer object (in this case a `Feature`) until there are no more messages: the client needs to check the return value of `Read()` after each call. If `true`, the stream is still good and it can continue reading; if `false` the message stream has ended. Finally, we call `Finish()` on the stream to complete the call and get our RPC status.
@@ -329,31 +329,31 @@ Instead of passing the method a context, request, and response, we pass it a con
 The client-side streaming method `RecordRoute` is similar, except there we pass the method a context and response object and get back a `ClientWriter`.
 
 ```cpp
-    std::unique_ptr<ClientWriter<Point> > writer(
-        stub_->RecordRoute(&context, &stats));
-    for (int i = 0; i < kPoints; i++) {
-      const Feature& f = feature_list_[feature_distribution(generator)];
-      std::cout << "Visiting point "
-                << f.location().latitude()/kCoordFactor_ << ", "
-                << f.location().longitude()/kCoordFactor_ << std::endl;
-      if (!writer->Write(f.location())) {
-        // Broken stream.
-        break;
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(
-          delay_distribution(generator)));
-    }
-    writer->WritesDone();
-    Status status = writer->Finish();
-    if (status.IsOk()) {
-      std::cout << "Finished trip with " << stats.point_count() << " points\n"
-                << "Passed " << stats.feature_count() << " features\n"
-                << "Travelled " << stats.distance() << " meters\n"
-                << "It took " << stats.elapsed_time() << " seconds"
-                << std::endl;
-    } else {
-      std::cout << "RecordRoute rpc failed." << std::endl;
-    }
+std::unique_ptr<ClientWriter<Point> > writer(
+    stub_->RecordRoute(&context, &stats));
+for (int i = 0; i < kPoints; i++) {
+  const Feature& f = feature_list_[feature_distribution(generator)];
+  std::cout << "Visiting point "
+            << f.location().latitude()/kCoordFactor_ << ", "
+            << f.location().longitude()/kCoordFactor_ << std::endl;
+  if (!writer->Write(f.location())) {
+    // Broken stream.
+    break;
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(
+      delay_distribution(generator)));
+}
+writer->WritesDone();
+Status status = writer->Finish();
+if (status.IsOk()) {
+  std::cout << "Finished trip with " << stats.point_count() << " points\n"
+            << "Passed " << stats.feature_count() << " features\n"
+            << "Travelled " << stats.distance() << " meters\n"
+            << "It took " << stats.elapsed_time() << " seconds"
+            << std::endl;
+} else {
+  std::cout << "RecordRoute rpc failed." << std::endl;
+}
 ```
 
 Once we've finished writing our client's requests to the stream using `Write()`, we need to call `WritesDone()` on the stream to let gRPC know that we've finished writing, then `Finish()` to complete the call and get our RPC status. If the status is `OK`, our response object that we initially passed to `RecordRoute()` will be populated with the server's response.
@@ -361,8 +361,8 @@ Once we've finished writing our client's requests to the stream using `Write()`,
 Finally, let's look at our bidirectional streaming RPC `RouteChat()`. In this case, we just pass a context to the method and get back a `ClientReaderWriter`, which we can use to both write and read messages.
 
 ```cpp
-    std::shared_ptr<ClientReaderWriter<RouteNote, RouteNote> > stream(
-        stub_->RouteChat(&context));
+std::shared_ptr<ClientReaderWriter<RouteNote, RouteNote> > stream(
+    stub_->RouteChat(&context));
 ```
 
 The syntax for reading and writing here is exactly the same as for our client-streaming and server-streaming methods. Although each side will always get the other's messages in the order they were written, both the client and server can read and write in any order — the streams operate completely independently.

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -55,34 +55,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 - A *simple RPC* where the client sends a request to the server using the client object and waits for a response to come back, just like a normal function call.
 
 ```protobuf
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *server-side streaming RPC* where the client sends a request to the server and gets a stream to read a sequence of messages back. The client reads from the returned stream until there are no more messages. As you can see in our example, you specify a server-side streaming method by placing the `stream` keyword before the *response* type.
 
 ```protobuf
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages and sends them to the server, again using a provided stream. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a server-side streaming method by placing the `stream` keyword before the *request* type.
 
 ```protobuf
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages using a read-write stream. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```protobuf
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -112,7 +112,7 @@ To generate the code, the following command should be run from the `examples/csh
 - Windows
 
   ```
-  > packages\Grpc.Tools.0.14.0\tools\windows_x86\protoc.exe -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=packages\Grpc.Tools.0.14.0\tools\windows_x86\grpc_csharp_plugin.exe 
+  > packages\Grpc.Tools.0.14.0\tools\windows_x86\protoc.exe -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=packages\Grpc.Tools.0.14.0\tools\windows_x86\grpc_csharp_plugin.exe
   ```
 
 - Linux (or Mac OS X by using `macosx_x64` directory).

--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -57,34 +57,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 - A *simple RPC* where the client sends a request to the server using the stub and waits for a response to come back, just like a normal function call.
 
 ```proto
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *server-side streaming RPC* where the client sends a request to the server and gets a stream to read a sequence of messages back. The client reads from the returned stream until there are no more messages. As you can see in our example, you specify a server-side streaming method by placing the `stream` keyword before the *response* type.
 
 ```proto
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages and sends them to the server, again using a provided stream. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a client-side streaming method by placing the `stream` keyword before the *request* type.
 
 ```proto
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages using a read-write stream. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```proto
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:

--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -60,34 +60,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 - A *simple RPC* where the client sends a request to the server using the stub and waits for a response to come back, just like a normal function call.
 
 ```protobuf
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *server-side streaming RPC* where the client sends a request to the server and gets a stream to read a sequence of messages back. The client reads from the returned stream until there are no more messages. As you can see in our example, you specify a server-side streaming method by placing the `stream` keyword before the *response* type.
 
 ```protobuf
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages and sends them to the server, again using a provided stream. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a server-side streaming method by placing the `stream` keyword before the *request* type.
 
 ```protobuf
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages using a read-write stream. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```protobuf
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -296,9 +296,9 @@ stub.getFeature(point, function(err, feature) {
 As you can see, we create and populate a request object. Finally, we call the method on the stub, passing it the request and callback. If there is no error, then we can read the response information from the server from our response object.
 
 ```js
-      console.log('Found feature called "' + feature.name + '" at ' +
-          feature.location.latitude/COORD_FACTOR + ', ' +
-          feature.location.longitude/COORD_FACTOR);
+console.log('Found feature called "' + feature.name + '" at ' +
+    feature.location.latitude/COORD_FACTOR + ', ' +
+    feature.location.longitude/COORD_FACTOR);
 ```
 
 #### Streaming RPCs
@@ -325,35 +325,35 @@ Instead of passing the method a request and callback, we pass it a request and g
 The client-side streaming method `RecordRoute` is similar, except there we pass the method a callback and get back a `Writable`.
 
 ```js
-    var call = client.recordRoute(function(error, stats) {
-      if (error) {
-        callback(error);
-      }
-      console.log('Finished trip with', stats.point_count, 'points');
-      console.log('Passed', stats.feature_count, 'features');
-      console.log('Travelled', stats.distance, 'meters');
-      console.log('It took', stats.elapsed_time, 'seconds');
+var call = client.recordRoute(function(error, stats) {
+  if (error) {
+    callback(error);
+  }
+  console.log('Finished trip with', stats.point_count, 'points');
+  console.log('Passed', stats.feature_count, 'features');
+  console.log('Travelled', stats.distance, 'meters');
+  console.log('It took', stats.elapsed_time, 'seconds');
+});
+function pointSender(lat, lng) {
+  return function(callback) {
+    console.log('Visiting point ' + lat/COORD_FACTOR + ', ' +
+        lng/COORD_FACTOR);
+    call.write({
+      latitude: lat,
+      longitude: lng
     });
-    function pointSender(lat, lng) {
-      return function(callback) {
-        console.log('Visiting point ' + lat/COORD_FACTOR + ', ' +
-            lng/COORD_FACTOR);
-        call.write({
-          latitude: lat,
-          longitude: lng
-        });
-        _.delay(callback, _.random(500, 1500));
-      };
-    }
-    var point_senders = [];
-    for (var i = 0; i < num_points; i++) {
-      var rand_point = feature_list[_.random(0, feature_list.length - 1)];
-      point_senders[i] = pointSender(rand_point.location.latitude,
-                                     rand_point.location.longitude);
-    }
-    async.series(point_senders, function() {
-      call.end();
-    });
+    _.delay(callback, _.random(500, 1500));
+  };
+}
+var point_senders = [];
+for (var i = 0; i < num_points; i++) {
+  var rand_point = feature_list[_.random(0, feature_list.length - 1)];
+  point_senders[i] = pointSender(rand_point.location.latitude,
+                                 rand_point.location.longitude);
+}
+async.series(point_senders, function() {
+  call.end();
+});
 ```
 
 Once we've finished writing our client's requests to the stream using `write()`, we need to call `end()` on the stream to let gRPC know that we've finished writing. If the status is `OK`, the `stats` object will be populated with the server's response.

--- a/docs/tutorials/basic/objective-c.md
+++ b/docs/tutorials/basic/objective-c.md
@@ -94,36 +94,36 @@ service RouteGuide {
 Then you define `rpc` methods inside your service definition, specifying their request and response types. Protocol buffers let you define four kinds of service method, all of which are used in the `RouteGuide` service:
 
 - A *simple RPC* where the client sends a request to the server and receives a response later, just like a normal remote procedure call.
- 
+
 ```protobuf
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *response-streaming RPC* where the client sends a request to the server and gets back a stream of response messages. You specify a response-streaming method by placing the `stream` keyword before the *response* type.
 
 ```protobuf
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *request-streaming RPC* where the client sends a sequence of messages to the server. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a request-streaming method by placing the `stream` keyword before the *request* type.
- 
+
 ```protobuf
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages to the other. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```protobuf
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -238,14 +238,14 @@ NSLog(@"Found feature called %@ at %@.", response.name, response.location);
 Now let's look at our streaming methods. Here's where we call the response-streaming method `ListFeatures`, which results in our client app receiving a stream of geographical `RTGFeature`s:
 
 ```
-  [service listFeaturesWithRequest:rectangle
-                      eventHandler:^(BOOL done, RTGFeature *response, NSError *error) {
-    if (response) {
-      NSLog(@"Found feature at %@ called %@.", response.location, response.name);
-    } else if (error) {
-      NSLog(@"RPC error: %@", error);
-    }
-  }];
+[service listFeaturesWithRequest:rectangle
+                    eventHandler:^(BOOL done, RTGFeature *response, NSError *error) {
+  if (response) {
+    NSLog(@"Found feature at %@ called %@.", response.location, response.name);
+  } else if (error) {
+    NSLog(@"RPC error: %@", error);
+  }
+}];
 ```
 
 Notice how the signature of the handler block now includes a `BOOL done` parameter. The handler block can be called any number of times; only on the last call is the `done` argument value set to `YES`. If an error occurs, the RPC finishes and the handler is called with the arguments `(YES, nil, error)`.

--- a/docs/tutorials/basic/php.md
+++ b/docs/tutorials/basic/php.md
@@ -90,34 +90,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 - A *simple RPC* where the client sends a request to the server and receives a response later, just like a normal remote procedure call.
 
 ```protobuf
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *response-streaming RPC* where the client sends a request to the server and gets back a stream of response messages. You specify a response-streaming method by placing the `stream` keyword before the *response* type.
 
 ```protobuf
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *request-streaming RPC* where the client sends a sequence of messages to the server. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a request-streaming method by placing the `stream` keyword before the *request* type.
 
 ```protobuf
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages to the other. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```protobuf
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -193,18 +193,18 @@ Now let's look at how we call our service methods.
 Calling the simple RPC `GetFeature` is nearly as straightforward as calling a local asynchronous method.
 
 ```php
-  $point = new examples\Point();
-  $point->setLatitude(409146138);
-  $point->setLongitude(-746188906);
-  list($feature, $status) = $client->GetFeature($point)->wait();
+$point = new examples\Point();
+$point->setLatitude(409146138);
+$point->setLongitude(-746188906);
+list($feature, $status) = $client->GetFeature($point)->wait();
 ```
 
 As you can see, we create and populate a request object, i.e. an `examples\Point` object. Then, we call the method on the stub, passing it the request object. If there is no error, then we can read the response information from the server from our response object, i.e. an `examples\Feature` object.
 
 ```php
-  print sprintf("Found %s \n  at %f, %f\n", $feature->getName(),
-                $feature->getLocation()->getLatitude() / COORD_FACTOR,
-                $feature->getLocation()->getLongitude() / COORD_FACTOR);
+print sprintf("Found %s \n  at %f, %f\n", $feature->getName(),
+              $feature->getLocation()->getLatitude() / COORD_FACTOR,
+              $feature->getLocation()->getLongitude() / COORD_FACTOR);
 ```
 
 #### Streaming RPCs
@@ -212,24 +212,24 @@ As you can see, we create and populate a request object, i.e. an `examples\Point
 Now let's look at our streaming methods. Here's where we call the server-side streaming method `ListFeatures`, which returns a stream of geographical `Feature`s:
 
 ```php
-  $lo_point = new examples\Point();
-  $hi_point = new examples\Point();
+$lo_point = new examples\Point();
+$hi_point = new examples\Point();
 
-  $lo_point->setLatitude(400000000);
-  $lo_point->setLongitude(-750000000);
-  $hi_point->setLatitude(420000000);
-  $hi_point->setLongitude(-730000000);
+$lo_point->setLatitude(400000000);
+$lo_point->setLongitude(-750000000);
+$hi_point->setLatitude(420000000);
+$hi_point->setLongitude(-730000000);
 
-  $rectangle = new examples\Rectangle();
-  $rectangle->setLo($lo_point);
-  $rectangle->setHi($hi_point);
+$rectangle = new examples\Rectangle();
+$rectangle->setLo($lo_point);
+$rectangle->setHi($hi_point);
 
-  $call = $client->ListFeatures($rectangle);
-  // an iterator over the server streaming responses
-  $features = $call->responses();
-  foreach ($features as $feature) {
-    // process each feature
-  } // the loop will end when the server indicates there is no more responses to be sent.
+$call = $client->ListFeatures($rectangle);
+// an iterator over the server streaming responses
+$features = $call->responses();
+foreach ($features as $feature) {
+  // process each feature
+} // the loop will end when the server indicates there is no more responses to be sent.
 ```
 
 The `$call->responses()` method call returns an iterator. When the server sends a response, a `$feature` object will be returned in the `foreach` loop, until the server indiciates that there will be no more responses to be sent.
@@ -237,16 +237,16 @@ The `$call->responses()` method call returns an iterator. When the server sends 
 The client-side streaming method `RecordRoute` is similar, except that we call `$call->write($point)` for each point we want to write from the client side and get back a `examples\RouteSummary`.
 
 ```php
-  $call = $client->RecordRoute();
+$call = $client->RecordRoute();
 
-  for ($i = 0; $i < $num_points; $i++) {
-    $point = new examples\Point();
-    $point->setLatitude($lat);
-    $point->setLongitude($long);
-    $call->write($point);
-  }
+for ($i = 0; $i < $num_points; $i++) {
+  $point = new examples\Point();
+  $point->setLatitude($lat);
+  $point->setLongitude($long);
+  $call->write($point);
+}
 
-  list($route_summary, $status) = $call->wait();
+list($route_summary, $status) = $call->wait();
 ```
 
 Finally, let's look at our bidirectional streaming RPC `routeChat()`. In this case, we just pass a context to the method and get back a `BidiStreamingCall` stream object, which we can use to both write and read messages.
@@ -258,19 +258,19 @@ $call = $client->RouteChat();
 To write messages from the client:
 
 ```php
-  foreach ($notes as $n) {
-    $route_note = new examples\RouteNote();
-    $call->write($route_note);
-  }
-  $call->writesDone();
+foreach ($notes as $n) {
+  $route_note = new examples\RouteNote();
+  $call->write($route_note);
+}
+$call->writesDone();
 ```
 
 To read messages from the server:
 
 ```php
-  while ($route_note_reply = $call->read()) {
-    // process $route_note_reply
-  }
+while ($route_note_reply = $call->read()) {
+  // process $route_note_reply
+}
 ```
 
 Each side will always get the other's messages in the order they were written, both the client and server can read and write in any order — the streams operate completely independently.

--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -58,34 +58,34 @@ Then you define `rpc` methods inside your service definition, specifying their r
 
 - A *simple RPC* where the client sends a request to the server using the stub and waits for a response to come back, just like a normal function call.
 ```protobuf
-   // Obtains the feature at a given position.
-   rpc GetFeature(Point) returns (Feature) {}
+// Obtains the feature at a given position.
+rpc GetFeature(Point) returns (Feature) {}
 ```
 
 - A *server-side streaming RPC* where the client sends a request to the server and gets a stream to read a sequence of messages back. The client reads from the returned stream until there are no more messages. As you can see in our example, you specify a server-side streaming method by placing the `stream` keyword before the *response* type.
 
 ```protobuf
-  // Obtains the Features available within the given Rectangle.  Results are
-  // streamed rather than returned at once (e.g. in a response message with a
-  // repeated field), as the rectangle may cover a large area and contain a
-  // huge number of features.
-  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+// Obtains the Features available within the given Rectangle.  Results are
+// streamed rather than returned at once (e.g. in a response message with a
+// repeated field), as the rectangle may cover a large area and contain a
+// huge number of features.
+rpc ListFeatures(Rectangle) returns (stream Feature) {}
 ```
 
 - A *client-side streaming RPC* where the client writes a sequence of messages and sends them to the server, again using a provided stream. Once the client has finished writing the messages, it waits for the server to read them all and return its response. You specify a server-side streaming method by placing the `stream` keyword before the *request* type.
 
 ```protobuf
-  // Accepts a stream of Points on a route being traversed, returning a
-  // RouteSummary when traversal is completed.
-  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+// Accepts a stream of Points on a route being traversed, returning a
+// RouteSummary when traversal is completed.
+rpc RecordRoute(stream Point) returns (RouteSummary) {}
 ```
 
 - A *bidirectional streaming RPC* where both sides send a sequence of messages using a read-write stream. The two streams operate independently, so clients and servers can read and write in whatever order they like: for example, the server could wait to receive all the client messages before writing its responses, or it could alternately read a message then write a message, or some other combination of reads and writes. The order of messages in each stream is preserved. You specify this type of method by placing the `stream` keyword before both the request and the response.
 
 ```protobuf
-  // Accepts a stream of RouteNotes sent while a route is being traversed,
-  // while receiving other RouteNotes (e.g. from other users).
-  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+// Accepts a stream of RouteNotes sent while a route is being traversed,
+// while receiving other RouteNotes (e.g. from other users).
+rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
 ```
 
 Our .proto file also contains protocol buffer message type definitions for all the request and response types used in our service methods - for example, here's the `Point` message type:
@@ -147,12 +147,12 @@ class ServerImpl < RouteGuide::Service
 `ServerImpl` implements all our service methods. Let's look at the simplest type first, `GetFeature`, which just gets a `Point` from the client and returns the corresponding feature information from its database in a `Feature`.
 
 ```ruby
-  def get_feature(point, _call)
-    name = @feature_db[{
-      'longitude' => point.longitude,
-      'latitude' => point.latitude }] || ''
-    Feature.new(location: point, name: name)
-  end
+def get_feature(point, _call)
+  name = @feature_db[{
+    'longitude' => point.longitude,
+    'latitude' => point.latitude }] || ''
+  Feature.new(location: point, name: name)
+end
 ```
 
 The method is passed a _call for the RPC, the client's `Point` protocol buffer request, and returns a `Feature` protocol buffer. In the method we create the `Feature` with the appropriate information, and then `return` it.
@@ -172,25 +172,25 @@ As you can see, here the request object is a `Rectangle` in which our client wan
 Similarly, the client-side streaming method `record_route` uses an [Enumerable](http://ruby-doc.org//core-2.2.0/Enumerable.html), but here it's obtained from the call object, which we've ignored in the earlier examples.  `call.each_remote_read` yields each message sent by the client in turn.
 
 ```ruby
-  call.each_remote_read do |point|
-    ...
-  end
+call.each_remote_read do |point|
+  ...
+end
 ```
 Finally, let's look at our bidirectional streaming RPC `route_chat`.
 
 ```ruby
-  def route_chat(notes)
-    q = EnumeratorQueue.new(self)
-    t = Thread.new do
-      begin
-        notes.each do |n|
-		...
+def route_chat(notes)
+  q = EnumeratorQueue.new(self)
+  t = Thread.new do
+    begin
+      notes.each do |n|
+      	...
+    end
       end
-	end
-    q = EnumeratorQueue.new(self)
-  ...
-    return q.each_item
-  end
+  q = EnumeratorQueue.new(self)
+...
+  return q.each_item
+end
 ```
 
 Here the method receives an [Enumerable](http://ruby-doc.org//core-2.2.0/Enumerable.html), but also returns an [Enumerator](http://ruby-doc.org//core-2.2.0/Enumerator.html) that yields the responses.  The implementation demonstrates how to set these up so that the requests and responses can be handled concurrently.  Although each side will always get the other's messages in the order they were written, both the client and server can read and write in any order — the streams operate completely independently.
@@ -200,11 +200,11 @@ Here the method receives an [Enumerable](http://ruby-doc.org//core-2.2.0/Enumera
 Once we've implemented all our methods, we also need to start up a gRPC server so that clients can actually use our service. The following snippet shows how we do this for our `RouteGuide` service:
 
 ```ruby
-  s = GRPC::RpcServer.new
-  s.add_http2_port(port, :this_port_is_insecure)
-  logger.info("... running insecurely on #{port}")
-  s.handle(ServerImpl.new(feature_db))
-  s.run_till_terminated
+s = GRPC::RpcServer.new
+s.add_http2_port(port, :this_port_is_insecure)
+logger.info("... running insecurely on #{port}")
+s.handle(ServerImpl.new(feature_db))
+s.run_till_terminated
 ```
 As you can see, we build and start our server using a `GRPC::RpcServer`. To do this, we:
 
@@ -226,7 +226,7 @@ To call service methods, we first need to create a *stub*.
 We use the `Stub` class of the `RouteGuide` module generated from our .proto.
 
 ```ruby
- stub = RouteGuide::Stub.new('localhost:50051')
+stub = RouteGuide::Stub.new('localhost:50051')
 ```
 
 ### Calling service methods
@@ -258,26 +258,26 @@ As you can see, we create and populate a request protocol buffer object (in our 
 Now let's look at our streaming methods. If you've already read [Creating the server](#server) some of this may look very familiar - streaming RPCs are implemented in a similar way on both sides. Here's where we call the server-side streaming method `list_features`, which returns an `Enumerable` of `Features`
 
 ```ruby
-  resps = stub.list_features(LIST_FEATURES_RECT)
-  resps.each do |r|
-    p "- found '#{r.name}' at #{r.location.inspect}"
-  end
+resps = stub.list_features(LIST_FEATURES_RECT)
+resps.each do |r|
+  p "- found '#{r.name}' at #{r.location.inspect}"
+end
 ```
 
 The client-side streaming method `record_route` is similar, except there we pass the server an `Enumerable`.
 
 ```ruby
-  ...
-  reqs = RandomRoute.new(features, points_on_route)
-  resp = stub.record_route(reqs.each, deadline)
-  ...
+...
+reqs = RandomRoute.new(features, points_on_route)
+resp = stub.record_route(reqs.each, deadline)
+...
 ```
 
 Finally, let's look at our bidirectional streaming RPC `route_chat`. In this case, we pass `Enumerable` to the method and get back an `Enumerable`.
 
 ```ruby
-  resps = stub.route_chat(ROUTE_CHAT_NOTES)
-  resps.each { |r| p "received #{r.inspect}" }
+resps = stub.route_chat(ROUTE_CHAT_NOTES)
+resps.each { |r| p "received #{r.inspect}" }
 ```
 
 Although it's not shown well by this example, each enumerable is independent of the other - both the client and server can read and write in any order — the streams operate completely independently.


### PR DESCRIPTION
The new website doesn't have as much vertical space. We don't want to
waste that space on avoidable indentation.

Note for reviewers: this change only includes whitespace changes, as verified with `git diff -w`