### PR TITLE
Change mailing list link to a URL to Google Groups

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -54,7 +54,7 @@ headline: 'Community'
 
                 <section class="community-section">
                     <h4 class="community-mailing community-title">Mailing List</h4>
-                        <p>Any questions or suggestions? Just want to be in the loop of what is going on with the project? <a href="mailto:grpc-io@googlegroups.com"> Join the mailing list<span class="external-link-icon"></span></a>
+                        <p>Any questions or suggestions? Just want to be in the loop of what is going on with the project? Join the <a href="https://groups.google.com/forum/#!forum/grpc-io">mailing list</a>
                 </section>
 
                 <section class="community-section">


### PR DESCRIPTION
Using mailto: to a mailing list via a link that says "Join the mailing
list" seems like a sure way to get people to send an email with
"subscribe" as the subject. Upon reflection, we've decided we don't want
that.