### PR TITLE
Link shortcuts on community page to actual pages

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -22,7 +22,7 @@ headline: 'Community'
                                 <a class="item-box" href="https://github.com/grpc/grpc/labels/help%20wanted">
                                     <p class="item-link">gRPC C-based</p>
                                 </a>
-                                <p class="item-desc">Or shortcut to: <a href="#">C></a>, <a href="#">C++ ></a>, <a href="#">Node.js ></a>, <a href="#">Python ></a>, <a href="#">Ruby ></a>, <a href="#">Objective-C ></a>, <a href="#">PHP ></a>, and <a href="#">C# ></a>
+                                <p class="item-desc">Or shortcut to: <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Acore">C</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Ac%2B%2B">C++</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Anode">Node.js</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Apython">Python</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Aruby">Ruby</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3AObjC">Objective-C</a>, <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3Aphp">PHP</a>, and <a href="https://github.com/grpc/grpc/issues?utf8=%E2%9C%93&q=is%3Aopen%20label%3A%22help%20wanted%22%20label%3AC%23">C#</a>
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
It looks a bit ugly, because there's a ton of the "external link" icons
without any left margin, but this is better than it was.