### PR TITLE
update basics with link to quickstart for ide issues

### DIFF
--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -495,17 +495,23 @@ using (var call = client.RouteChat())
 
 Build client and server:
 
-- Open the solution `examples/csharp/route_guide/RouteGuide.sln` from Visual
-  Studio (or Monodevelop on Linux) and select **Build**.
+#### Using Visual Studio
 
-- Run the server, which will listen on port 50052:
+- Open the solution `examples/csharp/route_guide/RouteGuide.sln` and select **Build**.
+
+#### Using Xamarin Studio or Monodevelop on OS X or Linux
+
+- See the [quickstart](../../quickstart/csharp.md) for instructions on downloading gRPC 
+  nuget dependencies and building the solution with these IDEs.
+
+Run the server, which will listen on port 50052:
 
   ```
   > cd RouteGuideServer/bin/Debug
   > RouteGuideServer.exe
   ```
 
-- Run the client (in a different terminal):
+Run the client (in a different terminal):
 
   ```
   > cd RouteGuideClient/bin/Debug


### PR DESCRIPTION
Left out this basics doc earlier, I think its short instructions on building the example at the end should refer to the quickstart instructions because of the issues with nuget, Xamarin Studio, and Monodevelop.