### PR TITLE
Fix file path of helloworld.proto

### DIFF
--- a/docs/quickstart/cpp.md
+++ b/docs/quickstart/cpp.md
@@ -108,7 +108,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` (from the root of the cloned repository) and
+`examples/protos/helloworld.proto` (from the root of the cloned repository) and
 update it with a new `SayHelloAgain` method, with the same request and response
 types:
 

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -142,7 +142,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` and update it with a new `SayHelloAgain`
+`examples/protos/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
 ```

--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -81,7 +81,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` and update it with a new `SayHelloAgain`
+`examples/protos/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
 ```proto

--- a/docs/quickstart/objective-c.md
+++ b/docs/quickstart/objective-c.md
@@ -147,7 +147,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` and update it with a new `SayHelloAgain`
+`examples/protos/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
 ```

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -114,7 +114,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` and update it with a new `SayHelloAgain`
+`examples/protos/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
 ```

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -128,7 +128,7 @@ message HelloReply {
 ```
 
 Let's update this so that the `Greeter` service has two methods. Edit
-`examples/proto/helloworld.proto` and update it with a new `SayHelloAgain`
+`examples/protos/helloworld.proto` and update it with a new `SayHelloAgain`
 method, with the same request and response types:
 
 ```


### PR DESCRIPTION
The directory in the grpc repo is `examples/protos`, not `examples/proto`.