### PR TITLE
clone v1.0.x branch in csharp examples

### DIFF
--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -56,7 +56,7 @@ and other tutorials):
 
 ```sh
 $ # Clone the repository to get the example code:
-$ git clone -b {{ site.data.config.grpc_release_branch }} https://github.com/grpc/grpc 
+$ git clone -b v1.0.x https://github.com/grpc/grpc 
 $ cd grpc
 ```
 

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -52,7 +52,7 @@ download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b {{ site.data.config.grpc_release_branch }} https://github.com/grpc/grpc
+$ git clone -b v1.0.x https://github.com/grpc/grpc
 $ cd grpc
 ```
 


### PR DESCRIPTION
helloworld and routeguide c# examples have pending changes not included in the v1.0.0 release (https://github.com/grpc/grpc/pull/7720). After https://github.com/grpc/grpc/pull/7720 is merged, the v1.0.x branch examples, rather than the v1.0.0 examples, should be correct.