### PR TITLE
adding android java to the main page

### DIFF
--- a/_includes/doc-call.html
+++ b/_includes/doc-call.html
@@ -9,18 +9,26 @@
                     <p class="lang-selector-text"> Or go straight to Quick Start in the language of your choice:</p>
                     <div class="lang-select-row">
                         <a href="{{site.baseurl}}/docs/quickstart/cpp.html" class="btn btn-grpc waves-effect inverse lang-select">C++</a>
-                        <a href="{{site.baseurl}}/docs/quickstart/go.html" class="btn btn-grpc waves-effect inverse lang-select">Go</a>
-                        <a href="{{site.baseurl}}/docs/quickstart/csharp.html" class="btn btn-grpc waves-effect inverse lang-select">C#</a>
-                    </div>
-                    <div class="lang-select-row">
                         <a href="{{site.baseurl}}/docs/quickstart/java.html" class="btn btn-grpc waves-effect inverse lang-select">Java</a>
-                        <a href="{{site.baseurl}}/docs/quickstart/ruby.html" class="btn btn-grpc waves-effect inverse lang-select">Ruby</a>
-                        <a href="{{site.baseurl}}/docs/quickstart/objective-c.html" class="btn btn-grpc waves-effect inverse lang-select">Objective-C</a>
+                        <a href="{{site.baseurl}}/docs/quickstart/python.html" class="btn btn-grpc waves-effect inverse lang-select">Python</a>
+
                     </div>
                     <div class="lang-select-row">
-                        <a href="{{site.baseurl}}/docs/quickstart/python.html" class="btn btn-grpc waves-effect inverse lang-select">Python</a>
-                        <a href="{{site.baseurl}}/docs/quickstart/node.html" class="btn btn-grpc waves-effect inverse lang-select">Node.js</a>
+                        <a href="{{site.baseurl}}/docs/quickstart/go.html" class="btn btn-grpc waves-effect inverse lang-select">Go</a>
+
+                        <a href="{{site.baseurl}}/docs/quickstart/ruby.html" class="btn btn-grpc waves-effect inverse lang-select">Ruby</a>
+                        <a href="{{site.baseurl}}/docs/quickstart/csharp.html" class="btn btn-grpc waves-effect inverse lang-select">C#</a>
+
+                    </div>
+                    <div class="lang-select-row">
+                      <a href="{{site.baseurl}}/docs/quickstart/node.html" class="btn btn-grpc waves-effect inverse lang-select">Node.js</a>
+                        <a href="{{site.baseurl}}/docs/quickstart/android.html" class="btn btn-grpc waves-effect inverse lang-select">Android Java</a>
+
+                        <a href="{{site.baseurl}}/docs/quickstart/objective-c.html" class="btn btn-grpc waves-effect inverse lang-select">Objective-C</a>
+		    </div>
+                    <div class="lang-select-row">
                         <a href="{{site.baseurl}}/docs/quickstart/php.html" class="btn btn-grpc waves-effect inverse lang-select">PHP</a>
+		    
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Add android java to the main page, follow up to #347 to ensure consistency. 
I also re-ordered the list of languages so that both pages are consistent. 
/cc @a11r 