### PR TITLE
Fix typo in node.js example

### DIFF
--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -377,7 +377,7 @@ need to call the RouteGuide stub constructor, specifying the server address and
 port.
 
 ```js
-new example.RouteGuide('localhost:50051', grpc.Credentials.createInsecure());
+new example.RouteGuide('localhost:50051', grpc.credentials.createInsecure());
 ```
 
 ### Calling service methods


### PR DESCRIPTION
`credentials` is with a lowercase `c`

![screen shot 2016-08-24 at 12 30 27](https://cloud.githubusercontent.com/assets/540683/17927622/cfd06ab6-69f6-11e6-8578-7e652bed9b96.png)
