### PR TITLE
Fix formatting of Network Failures table

### DIFF
--- a/docs/guides/error.md
+++ b/docs/guides/error.md
@@ -43,11 +43,8 @@ Server threw an exception (or did something other than returning a status code t
 
 Case | Status code
 -----|-----------
-No data transmitted before deadline expires. Also applies to cases where some
-data is transmitted and no other failures are detected before the deadline
-expires | GRPC&#95;STATUS&#95;DEADLINE_EXCEEDED Some data transmitted (for
-example, the request metadata has been written to the TCP connection) before the
-connection breaks | GRPC&#95;STATUS&#95;UNAVAILABLE
+No data transmitted before deadline expires. Also applies to cases where some data is transmitted and no other failures are detected before the deadline expires | GRPC&#95;STATUS&#95;DEADLINE_EXCEEDED
+Some data transmitted (for example, the request metadata has been written to the TCP connection) before the connection breaks | GRPC&#95;STATUS&#95;UNAVAILABLE
 
 
 ### Protocol errors


### PR DESCRIPTION
Reading http://www.grpc.io/docs/guides/error.html it was clear that this segment had been mangled by an edit.  Reverting it to state before change: https://github.com/grpc/grpc.github.io/commit/076c9c1e351bd099394e7cf557451682f72896df#diff-43cc74a26b167e70dcecef7f8857ad94L38