### PR TITLE
Add section on installing protoc

### DIFF
--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -63,6 +63,13 @@ and client stubs from
 but you'll need the tools for the rest of our quickstart, as well as later
 tutorials and your own projects.
 
+To install `protoc`:
+
+The simplest way to do this is to download pre-compiled binaries for your platform(`protoc-<version>-<platform>.zip`) from here: https://github.com/google/protobuf/releases
+
+  * Unzip this file.
+  * Update the environment variable `PATH` to include the path to the protoc binary file.
+
 To install Protobuf-PHP, run:
 
 ```sh


### PR DESCRIPTION
I missed that I needed protoc for Protobuf-PHP, so added a section (copy-paste from the Go quickstart) to outline how to install it, and make it more visible that it is required.