### PR TITLE
Update java release property 1.0.0

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -1,3 +1,3 @@
 grpc_release_branch: v1.0.0
-grpc_java_release_tag: v1.0.0-pre2
+grpc_java_release_tag: v1.0.0
 milestones_link: https://github.com/grpc/grpc/milestones


### PR DESCRIPTION
Just tested the quickstart with 1.0.0 and it worked perfectly - figured it made sense to update it to 1.0.0