### PR TITLE
Fix example for ruby server

### DIFF
--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -282,9 +282,10 @@ so that clients can actually use our service. The following snippet shows how we
 do this for our `RouteGuide` service:
 
 ```ruby
+addr = "0.0.0.0:8080"
 s = GRPC::RpcServer.new
-s.add_http2_port(port, :this_port_is_insecure)
-logger.info("... running insecurely on #{port}")
+s.add_http2_port(addr, :this_port_is_insecure)
+logger.info("... running insecurely on #{addr}")
 s.handle(ServerImpl.new(feature_db))
 s.run_till_terminated
 ```


### PR DESCRIPTION
Hi,

This fixes the confusing example. It didn't specify what kind `port` has. My first though was that is was an int:

``` ruby
s = GRPC::RpcServer.new
s.add_http2_port(8765, :this_port_is_insecure)

=> TypeError:
       no implicit conversion of Fixnum into String
```

Then, I tried as string:

``` ruby
s = GRPC::RpcServer.new
s.add_http2_port("8765", :this_port_is_insecure)
=> RuntimeError:
       could not add port 8765 to server, not sure why
```

Finally it worked with address string

``` ruby
s = GRPC::RpcServer.new
s.add_http2_port(":8765", :this_port_is_insecure)
```
