### PR TITLE
Fix protoc command on Windows 10

### DIFF
--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -247,7 +247,7 @@ From the `examples/csharp/helloworld` directory, or the `examples/csharp/hellowo
 **Windows**
 
 ```
-> packages/Grpc.Tools.{{ site.data.config.grpc_release_branch | remove_first: "v" }}/tools/windows_x86/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=packages/Grpc.Tools.{{ site.data.config.grpc_release_branch | remove_first: "v" }}/tools/windows_x86/grpc_csharp_plugin.exe
+> packages\Grpc.Tools.{{ site.data.config.grpc_release_branch | remove_first: "v" }}\tools\windows_x86\protoc.exe -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=packages/Grpc.Tools.{{ site.data.config.grpc_release_branch | remove_first: "v" }}/tools/windows_x86/grpc_csharp_plugin.exe
 ```
 
 **Linux (or OS X by using macosx_x64 directory)**


### PR DESCRIPTION
Use same syntax and convention as docs/tutorials/basic/csharp.md

Fix 'packages' is not recognized as an internal or external command, operable program or batch file.

![fixed_cmd](https://cloud.githubusercontent.com/assets/1173057/19059996/49d2df3a-89b2-11e6-9a44-29805900f21a.png)
