### PR TITLE
Document thread-safety of a service

### DIFF
--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -253,8 +253,8 @@ finished dealing with the RPC and that the `Feature` can be returned to the
 client.
 
 Note that all service methods can (and will!) be called from multiple threads at
-the same time. So you have to make sure that your method implementations are
-thread safe. In our example case here, `feature_list_` is never changed after
+the same time. You have to make sure that your method implementations are
+thread safe. In our example, `feature_list_` is never changed after
 construction, so it is safe by design. But if `feature_list_` would change during
 the lifetime of the service, we would need to synchronize access to this member.
 

--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -252,6 +252,12 @@ information, and then `return` with an `OK` status to tell gRPC that we've
 finished dealing with the RPC and that the `Feature` can be returned to the
 client.
 
+Note that all service methods can (and will!) be called from multiple threads at
+the same time. So you have to make sure that your method implementations are
+thread safe. In our example case here, `feature_list_` is never changed after
+construction, so it is safe by design. But if `feature_list_` would change during
+the lifetime of the service, we would need to synchronize access to this member.
+
 Now let's look at something a bit more complicated - a streaming RPC.
 `ListFeatures` is a server-side streaming RPC, so we need to send back multiple
 `Feature`s to our client.


### PR DESCRIPTION
A service should be implemented in a thread-safe way. A comment on the thread safety of the example service has been added.