### PR TITLE
Update python.md

### DIFF
--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -167,7 +167,7 @@ service definition.
 From the `examples/python/helloworld` directory, run:
 
 ```sh
-$ python -m grpc.tools.protoc -I../../protos --python_out=. --grpc_python_out=. ../../protos/route_guide.proto
+$ python -m grpc.tools.protoc -I../../protos --python_out=. --grpc_python_out=. ../../protos/helloworld.proto
 ```
 
 This regenerates `helloworld_pb2.py`, which contains our generated client and


### PR DESCRIPTION
example states wrong proto for recreation (route_guide instead of helloworld)