### PR TITLE
Correct broken markdown

### DIFF
--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -66,9 +66,8 @@ You also should have the relevant tools installed to generate the server and cli
 
 Our first step (as you'll know from the [Overview](/docs/index.html)) is to
 define the gRPC *service* and the method *request* and *response* types using
-[protocol buffers]
-(https://developers.google.com/protocol-buffers/docs/overview). You can see the
-complete .proto file in
+[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+You can see the complete .proto file in
 [`examples/route_guide/routeguide/route_guide.proto`](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/routeguide/route_guide.proto).
 
 To define a service, you specify a named `service` in your .proto file:


### PR DESCRIPTION
Previously sent to https://github.com/grpc/grpc-go/pull/972, but that seems to not be this website, but a fork of this tutorial.

The actual broken link on the website is on this page:
http://www.grpc.io/docs/tutorials/basic/go.html#defining-the-service