### PR TITLE
Fix typo in grpc node guide.

### DIFF
--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -377,7 +377,7 @@ need to call the RouteGuide stub constructor, specifying the server address and
 port.
 
 ```js
-new example.RouteGuide('localhost:50051', grpc.Credentials.createInsecure());
+new example.RouteGuide('localhost:50051', grpc.credentials.createInsecure());
 ```
 
 ### Calling service methods


### PR DESCRIPTION
`grpc.Credentials` should be `grpc.credentials` in grpc.