### PR TITLE
force list-nested p tags to have inline display

### DIFF
--- a/_sass/base/_override.scss
+++ b/_sass/base/_override.scss
@@ -37,6 +37,10 @@ a.disabled {
 p,
 li {line-height: 22px;}
 
+ul li p {
+    display: inline;
+}
+
 p.note {
   background-color: $thirdBrandColor;
   padding: 9.5px;


### PR DESCRIPTION
Fixes some display issues with lists on the [/about](http://www.grpc.io/about/) page.

## Before

<img width="602" alt="before" src="https://cloud.githubusercontent.com/assets/134032/21408414/cea3811e-c789-11e6-81a8-ea94959adcd6.png">

## After

<img width="591" alt="after" src="https://cloud.githubusercontent.com/assets/134032/21408423/d79e8138-c789-11e6-8d0e-ccf60bb4f518.png">

