### PR TITLE
PHP: update reference docs links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@ bodyclass: docs
           <div class="lang-card-title">PHP</div>
           <a class="lang-card-link" href="quickstart/php.html">Quick Start Guide</a>
           <a class="lang-card-link" href="tutorials/basic/php.html">gRPC Basics Tutorial</a>
-          <a class="lang-card-link" href="http://www.grpc.io/grpc/php/namespaces/Grpc.html">API Reference</a>
+          <a class="lang-card-link" href="http://www.grpc.io/grpc/php/namespace-Grpc.html">API Reference</a>
         </div>
       </div>
     </div>

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -273,7 +273,7 @@ In another terminal, from the `examples/php` directory:
   [Overview](http://www.grpc.io/docs/)
 - Work through a more detailed tutorial in [gRPC Basics: PHP][]
 - Explore the gRPC PHP core API in its [reference
-  documentation](http://www.grpc.io/grpc/php/namespaces/Grpc.html)
+  documentation](http://www.grpc.io/grpc/php/namespace-Grpc.html)
 
 [helloworld.proto]:../protos/helloworld.proto
 [gRPC Basics: PHP]:http://www.grpc.io/docs/tutorials/basic/php.html

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -15,7 +15,7 @@ type: markdown
   <li><a target="_blank" href="http://www.grpc.io/grpc/node/">Node.js API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/csharp/">C# API</a></li>
   <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">GO API</a></li>
-  <li><a target="_blank" href="http://www.grpc.io/grpc/php/namespaces/Grpc.html">PHP API</a></li>
+  <li><a target="_blank" href="http://www.grpc.io/grpc/php/namespace-Grpc.html">PHP API</a></li>
   <li><a target="_blank" href="http://cocoadocs.org/docsets/gRPC/">Objective-C API</a></li>
   <li><a target="_blank" href="http://www.grpc.io/grpc/core/">gRPC Core Lib (for wrapped languages).</a></ul></li>
 </ul>


### PR DESCRIPTION
I re-generated the PHP API docs with a different doc generator and need to update the website's links to these reference docs