### PR TITLE
Bump the grpc release version to v1.2.0

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -1,3 +1,3 @@
-grpc_release_branch: v1.0.0
-grpc_java_release_tag: v1.0.3
+grpc_release_branch: v1.2.0
+grpc_java_release_tag: v1.2.0
 milestones_link: https://github.com/grpc/grpc/milestones


### PR DESCRIPTION
Our guides often ask the user to issue a git
clone command which checkouts a branch specified
in grpc.io/release URL.  It is critical that the
release version gets updated as we ship new
versions. This patch bumps it from 1.0.0 to
1.2.0.

(c.f. https://github.com/grpc/grpc.github.io/issues/471)