### PR TITLE
Move tracking snippet to top of page and load async

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,6 +8,13 @@
     <meta name="description" content="A high-performance, open-source universal RPC framework. Client applications can directly call methods on a server application on a different machine as if it was a local object.">
     <title>grpc / {{ page.title }}</title>
 
+    <script>
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', 'UA-60127042-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <script async src='//www.google-analytics.com/analytics.js'></script>
+
     <!-- Webfont -->
     <link href='http://fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
 
@@ -73,17 +80,6 @@
     {% if page.path == 'blog/index.html' %}
       <script src="{{ site.baseurl }}/js/mc-validate.js"></script>
     {% endif %}
-    
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-60127042-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
 
     {% if page.customjs %}
       <script  async="" defer="" type="text/javascript" src="{{ page.customjs }}"></script>


### PR DESCRIPTION
This has two main benefits:

1.  The tracking snippet needs to be in <head> in order to use
    Google Search Console, which is the only way to see what
    search terms ended up directing users to grpc.io.  Without it,
    the search query shows up as the infamous "(not provided)".

2.  Page loads are faster.  The [analytics][1] page suggests
    putting it in the <head>.  Also, it suggests page loads are
    faster if using a modern browser.  Checkout our Google
    Analytics for grpc.io shows an overwhelming number of users
    with Chrome, Firefox, Safari.  For IE users (a small percent),
    most are using version 11 which supports async js.

[1]: https://developers.google.com/analytics/devguides/collection/analyticsjs/

cc: @LisaFC 