### PR TITLE
Correct deadlines/timeouts text

### DIFF
--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -173,18 +173,17 @@ request based on the response, and so on.
 
 <a name="deadlines"></a>
 
-### Deadlines
+### Deadlines/Timeouts
 
-gRPC allows clients to specify a deadline value when calling a remote method.
-This specifies how long the client wants to wait for a response from the server
-before the RPC finishes with the error `DEADLINE_EXCEEDED`. On the server side,
-the server can query the deadline to see if a particular method has timed out,
-or how much time is left to complete the method.
+gRPC allows clients to specify how long they are willing to wait for an RPC to
+complete before the RPC is terminated with the error `DEADLINE_EXCEEDED`. On
+the server side, the server can query to see if a particular RPC has timed out,
+or how much time is left to complete the RPC.
 
-How the deadline is specified varies from language to language - for example, a
-deadline value is always required in Python, and not all languages have a
-default deadline.
-
+How the deadline or timeout is specified varies from language to language - for
+example, not all languages have a default deadline, some language APIs work in
+terms of a deadline (a fixed point in time), and some language APIs work in
+terms of timeouts (durations of time).
 
 ### RPC termination
 


### PR DESCRIPTION
In particular it is no longer the case that a timeout must be specified when invoking an RPC with gRPC Python.