### PR TITLE
Some minor fixes

### DIFF
--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -29,12 +29,13 @@
   }
 
   // Lists
-  ol,
-  ul {
+  // Lists
+  ol,ul {
     list-style: initial;
-    list-style-position: inside;
+    list-style-position: disc outside;
     font-size: 15px;
     font-weight: 300;
+    margin-left: 1em;
     margin: 0 20px;
 
     @media (max-width: 768px) {

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -29,7 +29,6 @@
   }
 
   // Lists
-  // Lists
   ol,
   ul {
     list-style: initial;

--- a/_sass/base/_markdown.scss
+++ b/_sass/base/_markdown.scss
@@ -30,7 +30,8 @@
 
   // Lists
   // Lists
-  ol,ul {
+  ol,
+  ul {
     list-style: initial;
     list-style-position: disc outside;
     font-size: 15px;

--- a/_sass/pages/_about.scss
+++ b/_sass/pages/_about.scss
@@ -23,9 +23,9 @@
   }
 
   .about-lists {
-    list-style: disc inside;
+    list-style: disc outside;
+    margin-left: 1em;
     padding-left: 1em;
-    text-indent: -1em;
   }
 
   .intro {

--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -167,11 +167,10 @@ Just like we did before, from the `examples` directory:
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Android Java][]
 - Explore the gRPC Java core API in its [reference
   documentation](http://www.grpc.io/grpc-java/javadoc/)
 
-[gRPC Basics: Android Java]:http://www.grpc.io/docs/tutorials/basic/android.html
+[gRPC Basics: Android Java]:../tutorials/basic/android.html
 

--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -167,7 +167,8 @@ Just like we did before, from the `examples` directory:
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Android Java][]
 - Explore the gRPC Java core API in its [reference
   documentation](http://www.grpc.io/grpc-java/javadoc/)

--- a/docs/quickstart/cpp.md
+++ b/docs/quickstart/cpp.md
@@ -260,7 +260,8 @@ Just like we did before, from the `examples/cpp/helloworld` directory:
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: C++][]
 - Explore the gRPC C++ core API in its [reference
   documentation](http://www.grpc.io/grpc/cpp/)

--- a/docs/quickstart/cpp.md
+++ b/docs/quickstart/cpp.md
@@ -260,10 +260,9 @@ Just like we did before, from the `examples/cpp/helloworld` directory:
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: C++][]
 - Explore the gRPC C++ core API in its [reference
   documentation](http://www.grpc.io/grpc/cpp/)
 
-[gRPC Basics: C++]:http://www.grpc.io/docs/tutorials/basic/c.html
+[gRPC Basics: C++]:../tutorials/basic/c.html

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -364,7 +364,8 @@ Or if using the .NET Core SDK, from the `examples/csharp/helloworld-from-cli` di
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: C#][]
 - Explore the gRPC C# core API in its [reference
   documentation](http://www.grpc.io/grpc/csharp/)

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -364,11 +364,10 @@ Or if using the .NET Core SDK, from the `examples/csharp/helloworld-from-cli` di
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: C#][]
 - Explore the gRPC C# core API in its [reference
   documentation](http://www.grpc.io/grpc/csharp/)
 
 [helloworld.proto]:../protos/helloworld.proto
-[gRPC Basics: C#]:http://www.grpc.io/docs/tutorials/basic/csharp.html
+[gRPC Basics: C#]:../tutorials/basic/csharp.html

--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -206,7 +206,8 @@ Greeting: Hello again world
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Go][]
 - Explore the gRPC Go core API in its [reference
   documentation](https://godoc.org/google.golang.org/grpc)

--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -206,10 +206,9 @@ Greeting: Hello again world
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Go][]
 - Explore the gRPC Go core API in its [reference
   documentation](https://godoc.org/google.golang.org/grpc)
 
-[gRPC Basics: Go]:http://www.grpc.io/docs/tutorials/basic/go.html
+[gRPC Basics: Go]:../tutorials/basic/go.html

--- a/docs/quickstart/java.md
+++ b/docs/quickstart/java.md
@@ -196,11 +196,10 @@ Just like we did before, from the `examples` directory:
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Java][]
 - Explore the gRPC Java core API in its [reference
   documentation](http://www.grpc.io/grpc-java/javadoc/)
 
-[gRPC Basics: Java]:http://www.grpc.io/docs/tutorials/basic/java.html
+[gRPC Basics: Java]:../tutorials/basic/java.html
 

--- a/docs/quickstart/java.md
+++ b/docs/quickstart/java.md
@@ -196,7 +196,8 @@ Just like we did before, from the `examples` directory:
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Java][]
 - Explore the gRPC Java core API in its [reference
   documentation](http://www.grpc.io/grpc-java/javadoc/)

--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -170,7 +170,8 @@ Just like we did before, from the `examples/node/dynamic_codegen` directory:
 
 ## What's next
 
- - Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+ - Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+   and [gRPC Concepts](../guides/concepts.html)
  - Work through a more detailed tutorial in [gRPC Basics: Node][]
  - Explore the gRPC Node core API in its [reference
    documentation](http://www.grpc.io/grpc/node/)

--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -170,10 +170,9 @@ Just like we did before, from the `examples/node/dynamic_codegen` directory:
 
 ## What's next
 
- - Read a full explanation of this example and how gRPC works in our
-   [Overview](http://www.grpc.io/docs/)
+ - Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
  - Work through a more detailed tutorial in [gRPC Basics: Node][]
  - Explore the gRPC Node core API in its [reference
    documentation](http://www.grpc.io/grpc/node/)
 
-[gRPC Basics: Node]:http://www.grpc.io/docs/tutorials/basic/node.html
+[gRPC Basics: Node]:../tutorials/basic/node.html

--- a/docs/quickstart/objective-c.md
+++ b/docs/quickstart/objective-c.md
@@ -303,3 +303,12 @@ clone from Github, and build again.
 **Cannot find `protoc` when building HelloWorld**
 
 Run `brew install google-protobuf` to get `protoc` compiler.
+
+## What's next
+
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Work through a more detailed tutorial in [gRPC Basics: Objective-C][]
+- Explore the Objective-C core API in its [reference
+  documentation](http://cocoadocs.org/docsets/gRPC/)
+
+[gRPC Basics: Objective-C]:../tutorials/basic/objective-c.html

--- a/docs/quickstart/objective-c.md
+++ b/docs/quickstart/objective-c.md
@@ -306,7 +306,8 @@ Run `brew install google-protobuf` to get `protoc` compiler.
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Objective-C][]
 - Explore the Objective-C core API in its [reference
   documentation](http://cocoadocs.org/docsets/gRPC/)

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -281,7 +281,8 @@ In another terminal, from the `examples/php` directory:
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: PHP][]
 - Explore the gRPC PHP core API in its [reference
   documentation](http://www.grpc.io/grpc/php/namespace-Grpc.html)

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -281,11 +281,10 @@ In another terminal, from the `examples/php` directory:
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: PHP][]
 - Explore the gRPC PHP core API in its [reference
   documentation](http://www.grpc.io/grpc/php/namespace-Grpc.html)
 
 [helloworld.proto]:../protos/helloworld.proto
-[gRPC Basics: PHP]:http://www.grpc.io/docs/tutorials/basic/php.html
+[gRPC Basics: PHP]:../tutorials/basic/php.html

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -227,7 +227,8 @@ Just like we did before, from the `examples/python/helloworld` directory:
 
 ## What's next
 
-- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+  and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Python][]
 - Explore the gRPC Python core API in its [reference
   documentation](http://www.grpc.io/grpc/python/)

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -227,12 +227,11 @@ Just like we did before, from the `examples/python/helloworld` directory:
 
 ## What's next
 
-- Read a full explanation of this example and how gRPC works in our
-  [Overview](http://www.grpc.io/docs/)
+- Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
 - Work through a more detailed tutorial in [gRPC Basics: Python][]
 - Explore the gRPC Python core API in its [reference
   documentation](http://www.grpc.io/grpc/python/)
 
 [helloworld.proto]:../protos/helloworld.proto
-[gRPC Basics: Python]:http://www.grpc.io/docs/tutorials/basic/python.html
+[gRPC Basics: Python]:../tutorials/basic/python.html
 

--- a/docs/quickstart/ruby.md
+++ b/docs/quickstart/ruby.md
@@ -189,7 +189,8 @@ Just like we did before, from the `examples/ruby` directory:
 
 ## What's next
 
- - Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
+ - Read a full explanation of how gRPC works in [What is gRPC?](../guides/)
+   and [gRPC Concepts](../guides/concepts.html)
  - Work through a more detailed tutorial in [gRPC Basics: Ruby][]
  - Explore the gRPC Ruby core API in its [reference
    documentation](http://www.rubydoc.info/gems/grpc)

--- a/docs/quickstart/ruby.md
+++ b/docs/quickstart/ruby.md
@@ -189,10 +189,9 @@ Just like we did before, from the `examples/ruby` directory:
 
 ## What's next
 
- - Read a full explanation of this example and how gRPC works in our
-   [Overview](http://www.grpc.io/docs/)
+ - Read a full explanation of how gRPC works in [What is gRPC?](../guides/) and [gRPC Concepts](../guides/concepts.html)
  - Work through a more detailed tutorial in [gRPC Basics: Ruby][]
  - Explore the gRPC Ruby core API in its [reference
    documentation](http://www.rubydoc.info/gems/grpc)
 
-[gRPC Basics: Ruby]:http://www.grpc.io/docs/tutorials/basic/ruby.html
+[gRPC Basics: Ruby]:../tutorials/basic/ruby.html


### PR DESCRIPTION
Quickstarts: added and/or fixed the What's Next sections so they point to actual docs rather than just the doc overview page (I think the overview page's URL originally had something useful on it)

CSS: small fixes to our styling for lists so we don't keep ending up with lists with the bullets on different lines to the text. I *think* this works...