### PR TITLE
Changes type reference in description

### DIFF
--- a/docs/quickstart/java.md
+++ b/docs/quickstart/java.md
@@ -61,7 +61,7 @@ server for the client to call. Our gRPC service is defined using protocol
 buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: Java][]. For now all you need to know is that both the
 server and the client "stub" have a `SayHello` RPC method that takes a
-`HelloRequest` parameter from the client and returns a `HelloResponse` from the
+`HelloRequest` parameter from the client and returns a `HelloReply` from the
 server, and that this method is defined like this:
 
 


### PR DESCRIPTION
Changes return type HelloResponse to HelloReply in the description of the helloworld.proto definition.

The description states:

> For now all you need to know is that both the server and the client "stub" have a `SayHello` RPC
> method that takes a `HelloRequest` parameter from the client and returns a `HelloResponse` 
> from the server, and that this method is defined like this:
> 
> // The greeting service definition.
> service Greeter {
>     // Sends a greeting
>     rpc SayHello (HelloRequest) returns (HelloReply) {}
> }

so I think the SayHello RPC method returns a HelloReply from the server.
