### PR TITLE
Update grpc.io/release to 1.3.0

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -1,3 +1,3 @@
-grpc_release_branch: v1.2.0
-grpc_java_release_tag: v1.2.0
+grpc_release_branch: v1.3.0
+grpc_java_release_tag: v1.3.0
 milestones_link: https://github.com/grpc/grpc/milestones


### PR DESCRIPTION
Updates the latest release pointer to 1.3.

(Should be merged after release is made.)