### PR TITLE
Remove space that was breaking a link

### DIFF
--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -69,9 +69,8 @@ client interface code - if you don't already, follow the setup instructions in
 
 Our first step (as you'll know from the [Overview](/docs/index.html)) is to
 define the gRPC *service* and the method *request* and *response* types using
-[protocol buffers]
-(https://developers.google.com/protocol-buffers/docs/overview). You can see the
-complete .proto file in
+[protocol buffers](https://developers.google.com/protocol-buffers/docs/overview).
+You can see the complete .proto file in
 [`examples/protos/route_guide.proto`](https://github.com/grpc/grpc/blob/
 {{ site.data.config.grpc_release_branch }}/examples/protos/route_guide.proto).
 


### PR DESCRIPTION
Currently you can see the raw markdown and URL at http://www.grpc.io/docs/tutorials/basic/c.html#defining-the-service

![image](https://cloud.githubusercontent.com/assets/632207/26147687/94d4ed4a-3af4-11e7-8e9d-03b6519d3f2b.png)
