### PR TITLE
Add details on connecting to server from Android device/emulator

### DIFF
--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -14,8 +14,12 @@ working example.</p>
 
 ### Prerequisites
 
-* `JDK`: version 7 or higher
-* Android SDK
+*   `JDK`: version 7 or higher
+*   Android SDK
+*   An android device set up for [USB
+    debugging](https://developer.android.com/studio/command-line/adb.html#Enabling)
+    or an [Android Virtual
+    Device](https://developer.android.com/studio/run/managing-avds.html)
 
 ## Download the example
 
@@ -158,12 +162,37 @@ Just like we did before, from the `examples` directory:
    $ ./build/install/examples/bin/hello-world-server
    ```
 
-3. In another terminal, compile and run the client
+3. In another terminal, compile and install the client to your device
 
    ```sh
    $ cd android/helloworld
    $ ./gradlew installDebug
    ```
+
+#### Connecting to the Hello World server via USB
+
+To run the application on a physical device via USB debugging, you must
+configure USB port forwarding to allow the device to communicate with the server
+running on your computer. This is done via the `adb` command line tool as
+follows:
+
+```
+adb reverse tcp:8080 tcp:50051
+```
+
+This sets up port forwarding from port `8080` on the device to port `50051` on
+the connected computer, which is the port that the Hello World server is
+listening on.
+
+Now you can run the Android Hello World app on your device, using `localhost`
+and `8080` as the `Host` and `Port`.
+
+#### Connecting to the Hello World server from an Android Virtual Device
+
+To run the Hello World app on an Android Virtual Device, you don't need to
+enable port forwarding. Instead, the emulator can use the IP address
+`10.0.2.2` to refer to the host machine. Inside the Android Hello World app,
+enter `10.0.2.2` and `50051` as the `Host` and `Port`.
 
 ## What's next
 
@@ -174,4 +203,3 @@ Just like we did before, from the `examples` directory:
   documentation](http://www.grpc.io/grpc-java/javadoc/)
 
 [gRPC Basics: Android Java]:../tutorials/basic/android.html
-


### PR DESCRIPTION
This adds instructions for connecting the client app running on an Android physical or virtual device to the server running on their local machine. This should help anyone following the quickstart guide, as it's not obvious what to enter for the host/port on the client app unless you have previous experience with android.

cc @makdharma