### PR TITLE
Bump /release to 1.3.2

### DIFF
--- a/_data/config.yml
+++ b/_data/config.yml
@@ -1,3 +1,3 @@
-grpc_release_branch: v1.3.1
+grpc_release_branch: v1.3.2
 grpc_java_release_tag: v1.3.0
 milestones_link: https://github.com/grpc/grpc/milestones


### PR DESCRIPTION
Updating slipped `/release`
We need a better way to ensure tagging releases are followed by this version bump. 