### PR TITLE
Rename message in `Greeter` examples

### DIFF
--- a/docs/guides/concepts.md
+++ b/docs/guides/concepts.md
@@ -30,14 +30,14 @@ desired.
 
 ```
 service HelloService {
-  rpc SayHello (HelloRequest) returns (HelloResponse);
+  rpc SayHello (HelloRequest) returns (HelloReply);
 }
 
 message HelloRequest {
   string greeting = 1;
 }
 
-message HelloResponse {
+message HelloReply {
   string reply = 1;
 }
 ```
@@ -49,7 +49,7 @@ gRPC lets you define four kinds of service method:
   single response back, just like a normal function call.
 
 ```
-rpc SayHello(HelloRequest) returns (HelloResponse){
+rpc SayHello(HelloRequest) returns (HelloReply){
 }
 ```
 
@@ -58,7 +58,7 @@ rpc SayHello(HelloRequest) returns (HelloResponse){
   returned stream until there are no more messages.
 
 ```
-rpc LotsOfReplies(HelloRequest) returns (stream HelloResponse){
+rpc LotsOfReplies(HelloRequest) returns (stream HelloReply){
 }
 ```
 
@@ -68,7 +68,7 @@ rpc LotsOfReplies(HelloRequest) returns (stream HelloResponse){
   its response.
 
 ```
-rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse) {
+rpc LotsOfGreetings(stream HelloRequest) returns (HelloReply) {
 }
 ```
 
@@ -81,7 +81,7 @@ rpc LotsOfGreetings(stream HelloRequest) returns (HelloResponse) {
   stream is preserved.
 
 ```
-rpc BidiHello(stream HelloRequest) returns (stream HelloResponse){
+rpc BidiHello(stream HelloRequest) returns (stream HelloReply){
 }
 ```
 

--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -65,7 +65,7 @@ server for the client to call. Our gRPC service is defined using protocol
 buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: Android Java][]. For now all you need to know is that both the
 server and the client "stub" have a `SayHello` RPC method that takes a
-`HelloRequest` parameter from the client and returns a `HelloResponse` from the
+`HelloRequest` parameter from the client and returns a `HelloReply` from the
 server, and that this method is defined like this:
 
 

--- a/docs/quickstart/cpp.md
+++ b/docs/quickstart/cpp.md
@@ -89,7 +89,7 @@ buffers; you can find out lots more about how to define a service in a `.proto`
 file in [What is gRPC?](http://www.grpc.io/docs/#what-is-grpc) and [gRPC Basics:
 C++][]. For now all you need to know is that both the server and the client
 "stub" have a `SayHello` RPC method that takes a `HelloRequest` parameter from
-the client and returns a `HelloResponse` from the server, and that this method
+the client and returns a `HelloReply` from the server, and that this method
 is defined like this:
 
 

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -154,7 +154,7 @@ server for the client to call. Our gRPC service is defined using protocol
 buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: C#][]. For now all you need to know is that both the
 server and the client "stub" have a `SayHello` RPC method that takes a
-`HelloRequest` parameter from the client and returns a `HelloResponse` from the
+`HelloRequest` parameter from the client and returns a `HelloReply` from the
 server, and that this method is defined like this:
 
 

--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -59,7 +59,7 @@ buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: Node][]. For now all you need
 to know is that both the server and the client "stub" have a `SayHello` RPC
 method that takes a `HelloRequest` parameter from the client and returns a
-`HelloResponse` from the server, and that this method is defined like this:
+`HelloReply` from the server, and that this method is defined like this:
 
 
 ```proto

--- a/docs/quickstart/objective-c.md
+++ b/docs/quickstart/objective-c.md
@@ -112,7 +112,7 @@ by pressing the Run button on the top left corner of Xcode window. You can check
 the calling code in `main.m` and see the results in Xcode's console.
 
 The code sends a `HLWHelloRequest` containing the string "Objective-C" to a
-local server. The server responds with a `HLWHelloResponse`, which contains a
+local server. The server responds with a `HLWHelloReply`, which contains a
 string "Hello Objective-C" that is then output to the console.
 
 Congratulations! You've just run a client-server application with gRPC.
@@ -126,7 +126,7 @@ file in Protocol Buffers
 [website](https://developers.google.com/protocol-buffers/). For now all you 
 need to know is that both the server and the client "stub" have a `SayHello`
 RPC method that takes a `HelloRequest` parameter from the client and returns a
-`HelloResponse` from the server, and that this method is defined like this:
+`HelloReply` from the server, and that this method is defined like this:
 
 ```
 // The greeting service definition.

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -154,7 +154,7 @@ server for the client to call. Our gRPC service is defined using protocol
 buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: PHP][]. For now all you need to know is that both the
 server and the client "stub" have a `SayHello` RPC method that takes a
-`HelloRequest` parameter from the client and returns a `HelloResponse` from
+`HelloRequest` parameter from the client and returns a `HelloReply` from
 the server, and that this method is defined like this:
 
 

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -112,7 +112,7 @@ buffers; you can find out lots more about how to define a service in a `.proto`
 file in [What is gRPC?]() and [gRPC Basics: Python][]. For now all you need
 to know is that both the server and the client "stub" have a `SayHello` RPC
 method that takes a `HelloRequest` parameter from the client and returns a
-`HelloResponse` from the server, and that this method is defined like this:
+`HelloReply` from the server, and that this method is defined like this:
 
 
 ```

--- a/docs/quickstart/ruby.md
+++ b/docs/quickstart/ruby.md
@@ -79,7 +79,7 @@ buffers; you can find out lots more about how to define a service in a `.proto`
 file in [gRPC Basics: Ruby][]. For now all you need
 to know is that both the server and the client "stub" have a `SayHello` RPC
 method that takes a `HelloRequest` parameter from the client and returns a
-`HelloResponse` from the server, and that this method is defined like this:
+`HelloReply` from the server, and that this method is defined like this:
 
 
 ```proto


### PR DESCRIPTION
The message names in the desciprtion and in the code don't match. Seems to be a miss of the previous refactoring.

I've also renamed the messages in `docs/guides/concepts.md` to be consistent with other examples.