### PR TITLE
Fix ruby tutorial example runs

### DIFF
--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -397,11 +397,13 @@ Run the server, which will listen on port 50051:
 
 ```
 $ # from examples/ruby
-$ bundle exec route_guide/route_guide_server.rb
+$ bundle exec route_guide/route_guide_server.rb ../python/route_guide/route_guide_db.json
+$ # (note that the route_guide_db.json file is actually language-agnostic; it's just
+$ # located in the python folder).
 ```
 Run the client (in a different terminal):
 
 ```
 $ # from examples/ruby
-$ bundle exec route_guide/route_guide_client.rb
+$ bundle exec route_guide/route_guide_client.rb ../python/route_guide/route_guide_db.json
 ```


### PR DESCRIPTION
This provides the fix described in https://github.com/grpc/grpc.github.io/pull/501.

(the json file needs to be passed as an arg - added a comment)