### PR TITLE
Drop www from grpc.io

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.grpc.io
+grpc.io


### PR DESCRIPTION
Serve the contents from a clean `grpc.io` URL and drop the redirect to `www`.