### PR TITLE
Added community meeting notes blog post from 8/17

### DIFF
--- a/_posts/2017-08-17-community-meeting-update.md
+++ b/_posts/2017-08-17-community-meeting-update.md
@@ -5,7 +5,9 @@ published: true
 author: Jaye Pitzeruse
 company: Indeed
 company-link: https://www.indeed.com
----
+--- 
+
+**Next Community Meeting:** Thursday, August 31, 2017 11am Pacific Time (US and Canada)
 
 ## General Announcements
 
@@ -15,15 +17,15 @@ CloudNativeCon gathers all CNCF (Cloud Native Computing Foundation) projects und
 Presenters will be talking about their experiences with Kubernetes, Prometheus, OpenTracing, Fluentd, Linkerd, gRPC, CoreDNS, containerd, rkt and CNI.
 The call for papers period will be ending on Monday, August 21, 2017.
 The conference will be taking place on the 6th and 7th of December, 2017.
-If you submit a talk, please add an entry to the spreadsheet linked in the [gRPC Community Meeting Working Doc].
+If you submit a talk, please add an entry to the spreadsheet linked in the [gRPC Community Meeting Working Doc](https://docs.google.com/document/d/1DTMEbBNmzNbZBh8nOivsnnw3CwUr1Q7WGRe7rNxyHOU/edit#bookmark=id.7qk9qf3ri75m).
 
-Register for [CloudNativeCon]
+Register for [CloudNativeCon](https://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-north-america/attend/register)
 
 ## Release Updates
 
 1.6 will be available soon.
 The required changes have already been merged and published in the protocol buffer libraries.
-Keep your eyes pealed for the upcoming release.
+Keep your eyes peeled for the upcoming release.
 
 ## Platform Updates
 
@@ -32,6 +34,3 @@ No platform updates.
 ## Language Updates
 
 No language specific updates.
-
-[gRPC Community Meeting Working Doc]: https://docs.google.com/document/d/1DTMEbBNmzNbZBh8nOivsnnw3CwUr1Q7WGRe7rNxyHOU/edit#bookmark=id.7qk9qf3ri75m
-[CloudNativeCon]: https://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-north-america/attend/register

--- a/_posts/2017-08-17-community-meeting-update.md
+++ b/_posts/2017-08-17-community-meeting-update.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title: 2017-08-17 Community Meeting Update
+published: true
+author: Jaye Pitzeruse
+company: Indeed
+company-link: https://www.indeed.com
+---
+
+## General Announcements
+
+Call for Papers: CloudNativeCon
+
+CloudNativeCon gathers all CNCF (Cloud Native Computing Foundation) projects under a single roof. 
+Presenters will be talking about their experiences with Kubernetes, Prometheus, OpenTracing, Fluentd, Linkerd, gRPC, CoreDNS, containerd, rkt and CNI.
+The call for papers period will be ending on Monday, August 21, 2017.
+The conference will be taking place on the 6th and 7th of December, 2017.
+If you submit a talk, please add an entry to the spreadsheet linked in the [gRPC Community Meeting Working Doc].
+
+Register for [CloudNativeCon]
+
+## Release Updates
+
+1.6 will be available soon.
+The required changes have already been merged and published in the protocol buffer libraries.
+Keep your eyes pealed for the upcoming release.
+
+## Platform Updates
+
+No platform updates.
+
+## Language Updates
+
+No language specific updates.
+
+[gRPC Community Meeting Working Doc]: https://docs.google.com/document/d/1DTMEbBNmzNbZBh8nOivsnnw3CwUr1Q7WGRe7rNxyHOU/edit#bookmark=id.7qk9qf3ri75m
+[CloudNativeCon]: https://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-north-america/attend/register


### PR DESCRIPTION
Brought this up to April briefly about publishing a brief synopsis of the weekly meeting notes as a blog post. I rolled this up into 4 major sections: General Announcements, Release Updates, Platform Updates, and Language Updates. I'm working on back-porting notes from the first meeting, but that one had a lot more going on.

Let me know if there are any changes that need to be made.

CLA submitted