### PR TITLE
fix broken rubydoc links

### DIFF
--- a/docs/quickstart/ruby.md
+++ b/docs/quickstart/ruby.md
@@ -193,6 +193,6 @@ Just like we did before, from the `examples/ruby` directory:
    and [gRPC Concepts](../guides/concepts.html)
  - Work through a more detailed tutorial in [gRPC Basics: Ruby][]
  - Explore the gRPC Ruby core API in its [reference
-   documentation](https://www.rubydoc.info/gems/grpc)
+   documentation](http://www.rubydoc.info/gems/grpc)
 
 [gRPC Basics: Ruby]:../tutorials/basic/ruby.html

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -11,7 +11,7 @@ type: markdown
   <li><a target="_blank" href="/grpc/cpp/index.html">C++ API</a></li>
   <li><a target="_blank" href="/grpc-java/javadoc/index.html">Java API</a></li>
   <li><a target="_blank" href="/grpc/python/">Python API</a></li>
-  <li><a target="_blank" href="https://www.rubydoc.info/gems/grpc">Ruby API</a></li>
+  <li><a target="_blank" href="http://www.rubydoc.info/gems/grpc">Ruby API</a></li>
   <li><a target="_blank" href="/grpc/node/">Node.js API</a></li>
   <li><a target="_blank" href="/grpc/csharp/">C# API</a></li>
   <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">Go API</a></li>


### PR DESCRIPTION
https doesn't seem to work with rubydoc.info ATM