### PR TITLE
Add more link to community meeting blog post so that the headings are not corrupted

### DIFF
--- a/_posts/2017-08-17-community-meeting-update.md
+++ b/_posts/2017-08-17-community-meeting-update.md
@@ -9,6 +9,8 @@ company-link: https://www.indeed.com
 
 **Next Community Meeting:** Thursday, August 31, 2017 11am Pacific Time (US and Canada)
 
+<!--more-->
+
 ## General Announcements
 
 Call for Papers: CloudNativeCon


### PR DESCRIPTION
Minor cosmetic change to make blog headings work correctly.