### PR TITLE
Updating install instructions to avoid errors.

### DIFF
--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -30,7 +30,7 @@ For installation instructions, follow this guide: [Getting Started - The Go Prog
 Use the following command to install gRPC.
 
 ```sh
-$ go get google.golang.org/grpc
+$ go get -u google.golang.org/grpc
 ```
 
 #### Install Protocol Buffers v3


### PR DESCRIPTION
Trying to follow this guide and seeing this error while trying to run:

```
$ go get google.golang.org/grpc
# google.golang.org/grpc/transport
../../../google.golang.org/grpc/transport/http_util.go:486:6: f.fr.SetReuseFrames undefined (type *http2.Framer has no field or method SetReuseFrames)
```

I was able to solve the issue by adding `-u` to the go get command.

My go version (wasn't able to test with another version):
go version go1.9.1 darwin/amd64

Since I'm a go n00b I'd like someone to confirm if this pr adds some kind of value to people like me.