### PR TITLE
Fix link to Ruby docs

### DIFF
--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -11,7 +11,7 @@ type: markdown
   <li><a target="_blank" href="/grpc/cpp/index.html">C++ API</a></li>
   <li><a target="_blank" href="/grpc-java/javadoc/index.html">Java API</a></li>
   <li><a target="_blank" href="/grpc/python/">Python API</a></li>
-  <li><a target="_blank" href="https://www.rubydoc.info/gems/grpc">Ruby API</a></li>
+  <li><a target="_blank" href="http://www.rubydoc.info/gems/grpc">Ruby API</a></li>
   <li><a target="_blank" href="/grpc/node/">Node.js API</a></li>
   <li><a target="_blank" href="/grpc/csharp/api/Grpc.Core.html">C# API</a></li>
   <li><a target="_blank" href="https://godoc.org/google.golang.org/grpc">Go API</a></li>


### PR DESCRIPTION
Seems like Ruby docs are accessible at HTTP instead of HTTPS -- same as here:
https://grpc.io/docs/

🙇 