### PR TITLE
Fix error pointing to binaries that don't exist

### DIFF
--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -35,7 +35,7 @@ $ go get google.golang.org/grpc
 
 #### Install Protocol Buffers v3
 
-Install the protoc compiler that is used to generate gRPC service code. The simplest way to do this is to download pre-compiled binaries for your platform(`protoc-<version>-<platform>.zip`) from here: [https://github.com/google/protobuf/releases](https://github.com/google/protobuf/releases)
+First, install the standard C++ implementation of protocol buffers from [https://github.com/google/protobuf/releases](https://github.com/google/protobuf/releases)
 
   * Unzip this file.
   * run `./configure`, `make`, and `make install` from a terminal

--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -38,7 +38,7 @@ $ go get google.golang.org/grpc
 Install the protoc compiler that is used to generate gRPC service code. The simplest way to do this is to download pre-compiled binaries for your platform(`protoc-<version>-<platform>.zip`) from here: [https://github.com/google/protobuf/releases](https://github.com/google/protobuf/releases)
 
   * Unzip this file.
-  * Update the environment variable `PATH` to include the path to the protoc binary file.
+  * run `./configure`, `make`, and `make install` from a terminal
 
 Next, install the protoc plugin for Go
 


### PR DESCRIPTION
There were no binaries on the `protobuf` release page, there was only code which needs to be built