### PR TITLE
Add -u flag to go get grpc

### DIFF
--- a/docs/quickstart/go.md
+++ b/docs/quickstart/go.md
@@ -30,7 +30,7 @@ For installation instructions, follow this guide: [Getting Started - The Go Prog
 Use the following command to install gRPC.
 
 ```sh
-$ go get google.golang.org/grpc
+$ go get -u google.golang.org/grpc
 ```
 
 #### Install Protocol Buffers v3


### PR DESCRIPTION
Some updates have to be done on the http2 package when trying to compile grpc. Since the compilation fail if http2 package is not up-to-date, the `update` option should be passed to go get.