### PR TITLE
Fix Android tutorial to check out release tag

### DIFF
--- a/docs/tutorials/basic/android.md
+++ b/docs/tutorials/basic/android.md
@@ -30,7 +30,7 @@ With gRPC we can define our service once in a .proto file and implement clients 
 The example code for our tutorial is in [grpc-java's examples/android](https://github.com/grpc/grpc-java/tree/{{ site.data.config.grpc_release_branch }}/examples/android). To download the example, clone the `grpc-java` repository by running the following command:
 
 ```
-$ git clone https://github.com/grpc/grpc-java.git
+$ git clone -b {{ site.data.config.grpc_java_release_tag }} https://github.com/grpc/grpc-java.git
 ```
 
 Then change your current directory to `grpc-java/examples/android`:


### PR DESCRIPTION
Otherwise the example won't build, because it references SNAPSHOT
versions.