### PR TITLE
Specify gRPC minimum deployment version

### DIFF
--- a/docs/quickstart/objective-c.md
+++ b/docs/quickstart/objective-c.md
@@ -13,6 +13,8 @@ Objective-C with a simple working example.</p>
 ## Before you begin
 
 ### System requirement
+The minimum deployment iOS version for gRPC is 7.0.
+
 OS X El Capitan (version 10.11) or above is required to build and run this
 Quickstart.
 


### PR DESCRIPTION
Specify gRPC minimum deployment iOS version in quick start.