### PR TITLE
standardize path resolution for usage of githuburl variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ markdown:
 
 baseurl:
 
-githuburl: https://github.com/grpc/grpc.github.io/
+githuburl: https://github.com/grpc/grpc.github.io
 
 sass:
   style: compressed

--- a/js/common.js
+++ b/js/common.js
@@ -228,7 +228,7 @@ $(document).ready(function() {
         $("#generalInstructions").hide();
         $("#continueEdit").show();
         $("#continueEditButton").text("Edit " + forwarding);
-        $("#continueEditButton").attr("href", "{{ site.githuburl }}edit/master/" + forwarding)
+        $("#continueEditButton").attr("href", "{{ site.githuburl }}/edit/master/" + forwarding)
     } else {
         $("#generalInstructions").show();
         $("#continueEdit").hide();


### PR DESCRIPTION
fixes Github 'Edit' links on docs pages where a `//` is introduced, i.e.
`https://github.com/grpc/grpc.github.io//edit/master/docs/index.html`