### PR TITLE
Add privacy policy link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,7 @@
         <div class="left-links">
             <img class="footer-logo" src="{{ site.baseurl }}/img/grpc-gray.svg" alt="GRPC">
             <p class="description">&copy;&nbsp;2018 <a href="https://github.com/grpc/grpc/blob/master/AUTHORS">The gRPC Authors</a> | a <a href="https://www.cncf.io">Cloud Native Computing Foundation</a> project</p>
+            <p class="description"><a href="https://policies.google.com/privacy">Privacy Policy</a></p>
         </div>
         <div class="right-links">
             <div class="col-md-4 col-sm-4 col-xs-12 footer-documentation">


### PR DESCRIPTION
Because Google owns the google.io domain, legal says that we need to add a link to the privacy policy in our site.