### PR TITLE
Update to account for import error in generated python code

### DIFF
--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -71,7 +71,7 @@ tutorials and your own projects.
 To install gRPC tools, run:
 
 ```sh
-$ python -m pip install grpcio-tools
+$ python -m pip install grpcio-tools googleapis-common-protos
 ```
 
 ## Download the example

--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -160,6 +160,13 @@ First, install the grpcio-tools package:
 $ pip install grpcio-tools
 ```
 
+Then, install the googleapis-common-proto package which is a collection of
+generated python classes for some common protos:
+
+```
+$ pip install googleapis-common-protos
+```
+
 Use the following command to generate the Python code:
 
 ```


### PR DESCRIPTION
After generating relevant server/client code for python, the presence of

```python
from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
```
causes,

```bash
    from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
ImportError: No module named api
```

`pip install grpcio-tools` only brings in `google/protobuf` module.

Installing `googleapis-common-protos` causes the required files, specifically, 
`google/api/annotations_pb2.py` to be pulled in, thus resolving the import error.

There are examples like [python-grpc-hack.sh](https://github.com/kasey/grpc-example/blob/master/installers/python-grpc-hack.sh) out there, which is basically hacking
around the absence of the required module. I have not yet tried the Java codegen yet
but till the relevant protoc changes are pushed upstream, this change seems to be
the path of least resistance. 
What are your thoughts around this?

Related issue: [#298](https://github.com/grpc-ecosystem/grpc-gateway/issues/298).

Signed-off-by: Debosmit Ray <debo@uber.com>