### PR TITLE
Different cursor for clickable-header class

### DIFF
--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -29,6 +29,10 @@
   width: 100%; 
 }
 
+.clickable-header {
+  cursor: pointer;
+}
+
 .toc {
   border-left: 2px solid $light-gray;
   display: none !important;


### PR DESCRIPTION
When clicking on text that has the default text cursor, I don't expect the page to scroll. Changing the cursor to a pointer for this clickable-header class would provide a better user experience.