### PR TITLE
Fix link to build docs

### DIFF
--- a/docs/quickstart/cpp.md
+++ b/docs/quickstart/cpp.md
@@ -17,7 +17,7 @@ working example.</p>
 #### Install gRPC
 
 To install gRPC on your system, follow the [instructions to build from
-source](https://github.com/grpc/grpc/blob/master/INSTALL.md).
+source](https://github.com/grpc/grpc/blob/master/BUILDING.md).
 
 To run the example code, please ensure `pkg-config` is installed on your
 machine before you build and install gRPC in the previous step, since the


### PR DESCRIPTION
Changing to BUILDING.md because INSTALL.md was renamed to it in f389e5267afe7a7f735fd7e4c2f923640d2f72c5.