### PR TITLE
Fix duplicate 'data' event listing

### DIFF
--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -439,7 +439,7 @@ var call = client.listFeatures(rectangle);
           feature.location.latitude/COORD_FACTOR + ', ' +
           feature.location.longitude/COORD_FACTOR);
   });
-  call.on('data', function() {
+  call.on('end', function() {
     // The server has finished sending
   });
   call.on('error', function(e) {


### PR DESCRIPTION
The Node streaming example has a typo listing the `data` event twice, where it should reference `end` in the second case. :v: