### PR TITLE
Ensure all pages have a unique title

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="title" content="gRPC open-source universal RPC framework">
     <meta name="description" content="A high-performance, open-source universal RPC framework. Client applications can directly call methods on a server application on a different machine as if it was a local object.">
-    <title>grpc / {{ page.title }}</title>
+    <title>grpc / {{ page.title | page.headline }}</title>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
All pages ought to have a unique title. For several pages, no title is specified.
For all those pages, a headline is specified. 
Thus, falling back to a headline when a title does not exist fixes this problem.