### PR TITLE
Fix code snippet in 'gRPC Basics - Ruby'

### DIFF
--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -160,7 +160,7 @@ instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release
 Once that's done, the following command can be used to generate the ruby code.
 
 ```
-$ protoc -I ../../protos --ruby_out=../lib --grpc_out=../lib --plugin=protoc-gen-grpc=`which grpc_ruby_plugin` ../../protos/route_guide.proto
+$ grpc_tools_ruby_protoc -I ../../protos --ruby_out=../lib --grpc_out=../lib ../../protos/route_guide.proto
 ```
 
 Running this command regenerates the following files in the lib directory:


### PR DESCRIPTION
Under [this section](https://grpc.io/docs/tutorials/basic/ruby.html#generating-client-and-server-code), the following documented command does not work:

```
$ protoc -I ../../protos --ruby_out=../lib --grpc_out=../lib --plugin=protoc-gen-grpc=`which grpc_ruby_plugin` ../../protos/route_guide.proto
# route_guide.proto:15:10: Unrecognized syntax identifier "proto3".  This parser only recognizes "proto2".

$ which grpc_ruby_plugin
# nothing
```
Fix: Change command to use `grpc_tools_ruby_protoc` which is also used in [Ruby Quickstart tutorial](https://grpc.io/docs/quickstart/ruby.html#generate-grpc-code)
```
$ grpc_tools_ruby_protoc -I ../../protos --ruby_out=../lib --grpc_out=../lib ../../protos/route_guide.proto
```