### PR TITLE
Get rid of references to INSTALL.md

### DIFF
--- a/_posts/2016-4-4-installation.md
+++ b/_posts/2016-4-4-installation.md
@@ -32,7 +32,7 @@ Go | Linux, Mac, Windows | `go get google.golang.org/grpc`
 Objective-C | Mac | Runtime source fetched automatically from Github by Cocoapods
 C# | Windows | Install [gRPC NuGet package](https://www.nuget.org/packages/Grpc/) from your IDE (Visual Studio, Monodevelop, Xamarin Studio)
 Java | Linux, Mac, Windows | Use our [Maven and Gradle plugins](https://github.com/grpc/grpc-java/blob/master/README.md) that provide gRPC with [statically linked `boringssl`](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#openssl-statically-linked-netty-tcnative-boringssl-static)
-C++ | Linux, Mac, Windows | Currently requires [manual build and install](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/INSTALL.md)
+C++ | Linux, Mac, Windows | Currently requires [manual build and install](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/src/cpp/README.md)
 
 You can find out more about installation in our [Getting Started guide](/docs/#install-grpc) and Github repositories. Do send us your feedback on our [mailing list](https://groups.google.com/forum/#!forum/grpc-io) or file issues on our issue tracker if you run into any problems.
 

--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -162,7 +162,7 @@ For simplicity, we've provided a [Makefile](https://github.com/grpc/grpc/blob/
 that runs `protoc` for you with the appropriate plugin, input, and output (if
 you want to run this yourself, make sure you've installed protoc and followed
 the gRPC code [installation instructions](https://github.com/grpc/grpc/blob/
-{{ site.data.config.grpc_release_tag }}/INSTALL.md) first):
+{{ site.data.config.grpc_release_tag }}/src/cpp/README.md#make) first):
 
 ```
 $ make route_guide.grpc.pb.cc route_guide.pb.cc

--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -155,7 +155,7 @@ a special gRPC Ruby plugin.
 
 If you want to run this yourself, make sure you've installed protoc and followed
 the gRPC Ruby plugin [installation
-instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/INSTALL.md) first):
+instructions](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/src/cpp/README.md#make) first):
 
 Once that's done, the following command can be used to generate the ruby code.
 


### PR DESCRIPTION
Follow up for https://github.com/grpc/grpc/pull/15802 (where c++ installation instructions were moved so src/cpp, beside other changes)