### PR TITLE
Blog CSS adjustment

### DIFF
--- a/_sass/base/_common.scss
+++ b/_sass/base/_common.scss
@@ -36,10 +36,14 @@
 .toc {
   border-left: 2px solid $light-gray;
   display: none !important;
-  padding: 0;
+  padding: .75rem;
 
   @media (min-width: 768px) {
       display: block !important;
+  }
+
+  .toc-title {
+    margin-bottom: 1rem;
   }
 
   ul {

--- a/blog/index.html
+++ b/blog/index.html
@@ -66,7 +66,7 @@ headline:  'gRPC Blog'
 			
 			
 			<div id="blogtoc" class="toc col-sm-3">
-				<p>All blog posts:</p>
+				<h5 class="toc-title">All blog posts</h5>
 				<ul>
   {% for post in site.posts %}
     <li>


### PR DESCRIPTION
This PR contains some small HTML/CSS changes for the gRPC blog related to the list of posts on the right side.

Before:

<img width="302" alt="screen shot 2018-08-15 at 7 21 13 am" src="https://user-images.githubusercontent.com/1523104/44153045-f323b82c-a05b-11e8-9abb-17288d75cda7.png">


After:

<img width="315" alt="screen shot 2018-08-15 at 7 21 22 am" src="https://user-images.githubusercontent.com/1523104/44153053-f9865a1c-a05b-11e8-9536-7dfcd11201d5.png">