### PR TITLE
Dont hardcode the tag version in C# docs

### DIFF
--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -49,7 +49,7 @@ download the example, clone the `grpc` repository by running the following
 command:
 
 ```sh
-$ git clone -b v1.12.x https://github.com/grpc/grpc
+$ git clone -b {{ site.data.config.grpc_release_tag }} https://github.com/grpc/grpc
 $ cd grpc
 ```
 


### PR DESCRIPTION
As mentioned in https://github.com/grpc/grpc/issues/16397.

I grepped through the repository and didn't find any other occurrences.