### PR TITLE
Update C# quickstart and tutorial

### DIFF
--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -57,8 +57,6 @@ From the `examples/csharp/Helloworld` directory:
 > dotnet build Greeter.sln
 ```
 
-(if you're using dotnet SDK 1.x you need to run dotnet restore Greeter.sln first)
-
 *NOTE: If you want to use gRPC C# from a project that uses the old-style .csproj files (supported by Visual Studio 2013, 2015 and older versions of Mono), please refer to the
 [Greeter using legacy .csproj](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/examples/csharp/HelloworldLegacyCsproj/README.md) example.*
 
@@ -70,14 +68,14 @@ From the `examples/csharp/Helloworld` directory:
 
 ```
 > cd GreeterServer
-> dotnet run -f netcoreapp1.0
+> dotnet run -f netcoreapp2.1
 ```
 
 * In another terminal, run the client
 
 ```
 > cd GreeterClient
-> dotnet run -f netcoreapp1.0
+> dotnet run -f netcoreapp2.1
 ```
 
 Congratulations! You've just run a client-server application with gRPC.
@@ -244,14 +242,14 @@ Just like we did before, from the `examples/csharp/Helloworld` directory:
 
 ```
 > cd GreeterServer
-> dotnet run -f netcoreapp1.0
+> dotnet run -f netcoreapp2.1
 ```
 
 * In another terminal, run the client
 
 ```
 > cd GreeterClient
-> dotnet run -f netcoreapp1.0
+> dotnet run -f netcoreapp2.1
 ```
 
 ## What's next

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -22,7 +22,7 @@ example by using either an IDE and its build tools,
 or by using the the .NET Core SDK command line tools.
 
 First, make sure you have installed the
-[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/src/csharp/README.md#prerequisites](gRPC C# prerequisites).
+[gRPC C# prerequisites](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/src/csharp/README.md#prerequisites).
 You will also need Git to download the sample code.
 
 ## Download the example
@@ -39,7 +39,7 @@ $ cd grpc
 ```
 
 This document will walk you through the "Hello World" example.
-It can be found in the directory `examples/csharp/Helloworld`.
+The projects and source files can be found in the `examples/csharp/Helloworld` directory.
 
 The example in this walkthrough already adds the necessary
 dependencies for you (Grpc, Grpc.Tools and Google.Protobuf NuGet packages).
@@ -47,7 +47,7 @@ dependencies for you (Grpc, Grpc.Tools and Google.Protobuf NuGet packages).
 ## Build the example
 
 ### Using Visual Studio (or Visual Studio for Mac)
-* Open the solution `Greeter.sln` with Visual Studio.
+* Open the solution `Greeter.sln` with Visual Studio
 * Build the solution
 
 ### Using .NET Core SDK from the command line
@@ -60,7 +60,7 @@ From the `examples/csharp/Helloworld` directory:
 (if you're using dotnet SDK 1.x you need to run dotnet restore Greeter.sln first)
 
 *NOTE: If you want to use gRPC C# from a project that uses the old-style .csproj files (supported by Visual Studio 2013, 2015 and older versions of Mono), please refer to the
-[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/examples/csharp/HelloworldLegacyCsproj/README.md](Greeter using legacy .csproj) example.*
+[Greeter using legacy .csproj](https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/examples/csharp/HelloworldLegacyCsproj/README.md) example.*
 
 ## Run a gRPC application
 
@@ -145,8 +145,8 @@ The `Grpc.Tools` NuGet package contains the protoc and protobuf C# plugin binari
 
 ### Obtaining the Grpc.Tools NuGet package
 
-This example project already depends on the `Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}` NuGet package,
-so the package will be downloaded to your local NuGet cache as soon as you restore the nuget packages by clicking "Restore NuGet Packages" in Visual Studio or running dotnet restore RouteGuide.sln from the `examples/csharp/RouteGuide` directory.
+This example project already depends on the `Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}` NuGet package
+and the package will be downloaded to your local NuGet cache as soon as you restore the nuget packages by clicking "Restore NuGet Packages" in Visual Studio or running `dotnet restore RouteGuide.sln` from the `examples/csharp/RouteGuide` directory.
 
 ### Commands to generate the gRPC code
 Note that you may have to change the `platform_architecture` directory names (e.g. windows_x86, linux_x64) in the commands below based on your environment.
@@ -234,7 +234,7 @@ public static void Main(string[] args)
 ### Rebuild the modified example
 
 Rebuild the newly modified example just like we first built the original
-example by running the `dotnet build Greeter.sln`.
+example by running `dotnet build Greeter.sln`.
 
 ### Run!
 

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -21,30 +21,9 @@ Whether you're using Windows, OS X, or Linux, you can follow this
 example by using either an IDE and its build tools,
 or by using the the .NET Core SDK command line tools.
 
-Using the .NET Core SDK on Windows, OS X, or Linux, you'll need:
-
-* The .NET Core SDK command line tools. 
-* The .NET framework 4.5 (for OS X and Linux, the open source .NET Framework implementation, "Mono", at version 4+, is suitable) 
-* Git (to download the sample code)
-
-On Windows, using Visual Studio, you'll need: 
-
-* .NET Framework 4.5+
-* Visual Studio 2013 or 2015.
-* Git (to download the sample code)
-
-On OS X, using Xamarin Studio, you'll need:
-
-* Mono 4.4.2+ (or Mono 4+ is sufficient if you manually update NuGet to version 2.12+) 
-* Xamarin Studio 6.0+ 
-* Git (to download the sample code)
-
-On Linux, using the Monodevelop IDE, you'll need:
-
-* Mono 4.4.2+ (or Mono 4+ is sufficient if you manually update nuget to version 2.12+) 
-* MonoDevelop 5.9+
-* A NuGet executable, at version 2.12+ (you'll need to restore NuGet package dependencies from the command line)
-* Git (to download the sample code)
+First, make sure you have installed the
+[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/src/csharp/README.md#prerequisites](gRPC C# prerequisites).
+You will also need Git to download the sample code.
 
 ## Download the example
 
@@ -59,86 +38,46 @@ $ git clone -b {{ site.data.config.grpc_release_tag }} https://github.com/grpc/g
 $ cd grpc
 ```
 
-#### Using Visual Studio, Xamarin Studio, or Mondevelop IDEs
-
-* The examples are in the directory, `examples/csharp/helloworld`.
+This document will walk you through the "Hello World" example.
+It can be found in the directory `examples/csharp/Helloworld`.
 
 The example in this walkthrough already adds the necessary
 dependencies for you (Grpc, Grpc.Tools and Google.Protobuf NuGet packages).
 
 ## Build the example
 
-### Using Visual Studio
+### Using Visual Studio (or Visual Studio for Mac)
 * Open the solution `Greeter.sln` with Visual Studio.
-* Build the solution (this will automatically download NuGet dependencies)
-
-### Using Xamarin Studio
-* Open the solution `Greeter.sln` with Xamarin Studio.
-* Project->"Restore NuGet Packages"
-* Build the solution (this will automatically download NuGet dependencies)
+* Build the solution
 
 ### Using .NET Core SDK from the command line
-From the `examples/csharp/helloworld-from-cli` directory:
+From the `examples/csharp/Helloworld` directory:
 
 ```
-> dotnet restore
-> dotnet build **/project.json
+> dotnet build Greeter.sln
 ```
 
-### Using the Monodevelop IDE
-Using the Monodevelop IDE, you can build and edit a solution that uses gRPC 
-without issues, but unfortunately a workaround is necessary in order to initially restore
-a NuGet dependency on C# gRPC.
+(if you're using dotnet SDK 1.x you need to run dotnet restore Greeter.sln first)
 
-The problem is that C# gRPC package currently depends on 
-System.Interactive.Async 3.0.0, which requires NuGet 2.12+ to install.
-The NuGet included on the latest versions of Monodevelop is too old to install gRPC C#.
+*NOTE: If you want to use gRPC C# from a project that uses the old-style .csproj files (supported by Visual Studio 2013, 2015 and older versions of Mono), please refer to the
+[https://github.com/grpc/grpc/blob/{{ site.data.config.grpc_release_tag }}/examples/csharp/HelloworldLegacyCsproj/README.md](Greeter using legacy .csproj) example.*
 
-If you don't want to change the version of NuGet that you're using, 
-a possible workaround to get these files is to download the NuGet 
-package and unzip without a NuGet client, as follows.
-
-* Install NuGet 2.12+ so that it's available from the command line.
-* From the `examples/csharp/helloworld` directory, run `/path/to/nuget restore`. 
-* Now that the NuGet dependencies are restored into their proper package folders, build
-  the solution from the Monodevelop IDE.
-  
 ## Run a gRPC application
 
-### Using Visual Studio, Xamarin Studio, or Monodevelop IDEs
-From the `examples/csharp/helloworld` directory:
-
-* Run the server
-
-```
-> cd GreeterServer/bin/Debug
-> GreeterServer.exe
-```
-
-* In another terminal, run the client
-
-```
-> cd GreeterClient/bin/Debug
-> GreeterClient.exe
-```
-
-You'll need to run the above executables with "mono" if building on Xamarin Studio for OS X.
-
-###  Using the .NET Core SDK
+From the `examples/csharp/Helloworld` directory:
 
 * Run the server
 
 ```
 > cd GreeterServer
-> dotnet run
+> dotnet run -f netcoreapp1.0
 ```
-
 
 * In another terminal, run the client
 
 ```
 > cd GreeterClient
-> dotnet run
+> dotnet run -f netcoreapp1.0
 ```
 
 Congratulations! You've just run a client-server application with gRPC.
@@ -206,50 +145,26 @@ The `Grpc.Tools` NuGet package contains the protoc and protobuf C# plugin binari
 
 ### Obtaining the Grpc.Tools NuGet package
 
-#### Using Visual Studio
-
-This example project already depends on the `Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}` NuGet package, so it should be included in `examples/csharp/helloworld/packages` when the `Greeter.sln` solution is built from your IDE, 
-or when you restore packages via `/path/to/nuget restore` on the command line.
-
-#### If you have a NuGet client that is __not__ at version 2.12
-
-```
-$ mkdir packages && cd packages
-$ /path/to/nuget install Grpc.Tools
-```
-
-#### If you have a NuGet client that is at version 2.12
-
-NuGet 2.12 does not install the files from the `Grpc.Tools` package necessary on Linux and OS X.
-Without changing the version of NuGet that you're using, a possible workaround to obtaining the binaries included in the `Grpc.Tools` package 
-is by simply downloading the NuGet package and unzipping without a NuGet client, as follows.
-From your example directory:
-
-```
-$ temp_dir=packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tmp
-$ curl_url=https://www.nuget.org/api/v2/package/Grpc.Tools/{{ Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}
-$ mkdir -p $temp_dir && cd $temp_dir && curl -sL $curl_url > tmp.zip; unzip tmp.zip && cd .. && cp -r tmp/tools . && rm -rf tmp && cd ../..
-```
+This example project already depends on the `Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}` NuGet package,
+so the package will be downloaded to your local NuGet cache as soon as you restore the nuget packages by clicking "Restore NuGet Packages" in Visual Studio or running dotnet restore RouteGuide.sln from the `examples/csharp/RouteGuide` directory.
 
 ### Commands to generate the gRPC code
 Note that you may have to change the `platform_architecture` directory names (e.g. windows_x86, linux_x64) in the commands below based on your environment.
 
-Note that you may also have to change the permissions of the protoc and protobuf
-binaries in the `Grpc.Tools` package under `examples/csharp/helloworld/packages`
-to executable in order to run the commands below.
-
-From the `examples/csharp/helloworld` directory:
+From the `examples/csharp/Helloworld` directory:
 
 **Windows**
 
 ```
-> packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\protoc.exe -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/windows_x86/grpc_csharp_plugin.exe
+@rem Local nuget cache on Windows is located in %UserProfile%\.nuget\packages
+> %UserProfile%\.nuget\packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\protoc.exe -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=%UserProfile%\.nuget\packages\packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\grpc_csharp_plugin.exe
 ```
 
 **Linux (or OS X by using macosx_x64 directory)**
 
 ```
-$ packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
+# Local nuget cache on Linux and Mac is located in ~/.nuget/packages
+$ ~/.nuget/packages/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
 ```
 
 Running the appropriate command for your OS regenerates the following files in
@@ -319,43 +234,24 @@ public static void Main(string[] args)
 ### Rebuild the modified example
 
 Rebuild the newly modified example just like we first built the original
-example:
-
-* With solution Greeter.sln open from Visual Studio, Monodevelop (on Linux) or Xamarin Studio (on OS X)
-* Build the solution 
+example by running the `dotnet build Greeter.sln`.
 
 ### Run!
 
-Just like we did before, from the `examples/csharp/helloworld` directory:
-
-* Run the server
-
-```
-> cd GreeterServer/bin/Debug
-> GreeterServer.exe
-```
-
-* In another terminal, run the client
-
-```
-> cd GreeterClient/bin/Debug
-> GreeterClient.exe
-```
-
-Or if using the .NET Core SDK, from the `examples/csharp/helloworld-from-cli` directory:
+Just like we did before, from the `examples/csharp/Helloworld` directory:
 
 * Run the server
 
 ```
 > cd GreeterServer
-> dotnet run
+> dotnet run -f netcoreapp1.0
 ```
 
 * In another terminal, run the client
 
 ```
 > cd GreeterClient
-> dotnet run
+> dotnet run -f netcoreapp1.0
 ```
 
 ## What's next

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -512,14 +512,14 @@ using (var call = client.RouteChat())
 Run the server, which will listen on port 50052:
 
 ```
-> cd RouteGuideServer/bin/Debug/netcoreapp1.0
+> cd RouteGuideServer/bin/Debug/netcoreapp2.1
 > dotnet exec RouteGuideServer.dll
 ```
 
 Run the client (in a different terminal):
 
 ```
-> cd RouteGuideClient/bin/Debug/netcoreapp1.0
+> cd RouteGuideClient/bin/Debug/netcoreapp2.1
 > dotnet exec RouteGuideClient.dll
 ```
 

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -156,9 +156,7 @@ If you want to run this yourself, the `Grpc.Tools` NuGet package contains the
 binaries you will need to generate the code. You can fetch a copy of
 the `Grpc.Tools` package into your local nuget cache by clicking
 "Restore NuGet Packages" in Visual Studio or running `dotnet restore RouteGuide.sln`
-from the `examples/csharp/RouteGuide` directory.
-
-Once that's done, you can generate the C# code:
+from the `examples/csharp/RouteGuide` directory. Once that's done, you can generate the C# code.
 
 To generate the code, the following command should be run from the
 `examples/csharp/RouteGuide` directory:

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -153,7 +153,10 @@ service definition. We do this using the protocol buffer compiler `protoc` with
 a special gRPC C# plugin.
 
 If you want to run this yourself, the `Grpc.Tools` NuGet package contains the
-binaries you will need to generate the code.
+binaries you will need to generate the code. You can fetch a copy of
+the `Grpc.Tools` package into your local nuget cache by clicking
+"Restore NuGet Packages" in Visual Studio or running `dotnet restore RouteGuide.sln`
+from the `examples/csharp/RouteGuide`.
 
 Once that's done, you can generate the C# code:
 
@@ -163,13 +166,15 @@ To generate the code, the following command should be run from the
 - Windows
 
   ```
-  > packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\protoc.exe -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\grpc_csharp_plugin.exe
+  @rem Local nuget cache on Windows is located in %UserProfile%\.nuget\packages
+  > %UserProfile%\.nuget\packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\protoc.exe -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=%UserProfile%\.nuget\packages\Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}\tools\windows_x86\grpc_csharp_plugin.exe
   ```
 
 - Linux (or Mac OS X by using `macosx_x64` directory).
 
   ```
-  $ packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=packages/Grpc.Tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
+  # Local nuget cache on Linux and Mac is located in ~/.nuget/packages
+  $ ~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out RouteGuide --grpc_out RouteGuide ../../protos/route_guide.proto --plugin=protoc-gen-grpc=~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
   ```
 
 Running the appropriate command for your OS regenerates the following files in

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -43,8 +43,8 @@ updating.
 ## Example code and setup
 
 The example code for our tutorial is in
-[grpc/grpc/examples/csharp/route_guide](https://github.com/grpc/grpc/tree/
-{{ site.data.config.grpc_release_tag }}/examples/csharp/route_guide). To
+[grpc/grpc/examples/csharp/RouteGuide](https://github.com/grpc/grpc/tree/
+{{ site.data.config.grpc_release_tag }}/examples/csharp/RouteGuide). To
 download the example, clone the `grpc` repository by running the following
 command:
 
@@ -54,8 +54,8 @@ $ cd grpc
 ```
 
 All the files for this tutorial are in the directory
-`examples/csharp/route_guide`. Open the solution
-`examples/csharp/route_guide/RouteGuide.sln` from Visual Studio, Monodevelop or
+`examples/csharp/RouteGuide`. Open the solution
+`examples/csharp/RouteGuide/RouteGuide.sln` from Visual Studio, Monodevelop or
 Xamarin Studio. For additional installation details, see the [How to use
 instructions](https://github.com/grpc/grpc/tree/
 {{ site.data.config.grpc_release_tag }}/src/csharp#how-to-use).
@@ -158,7 +158,7 @@ binaries you will need to generate the code.
 Once that's done, you can generate the C# code:
 
 To generate the code, the following command should be run from the
-`examples/csharp/route_guide` directory:
+`examples/csharp/RouteGuide` directory:
 
 - Windows
 
@@ -202,8 +202,8 @@ There are two parts to making our `RouteGuide` service do its job:
   service responses.
 
 You can find our example `RouteGuide` server in
-[examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/
-{{ site.data.config.grpc_release_tag }}/examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs).
+[examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs](https://github.com/grpc/grpc/blob/
+{{ site.data.config.grpc_release_tag }}/examples/csharp/RouteGuide/RouteGuideServer/RouteGuideImpl.cs).
 Let's take a closer look at how it works.
 
 ### Implementing RouteGuide
@@ -373,8 +373,8 @@ do this, we:
 
 In this section, we'll look at creating a C# client for our `RouteGuide`
 service. You can see our complete example client code in
-[examples/csharp/route_guide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/
-{{ site.data.config.grpc_release_tag }}/examples/csharp/route_guide/RouteGuideClient/Program.cs).
+[examples/csharp/RouteGuide/RouteGuideClient/Program.cs](https://github.com/grpc/grpc/blob/
+{{ site.data.config.grpc_release_tag }}/examples/csharp/RouteGuide/RouteGuideClient/Program.cs).
 
 ### Creating a client object
 
@@ -498,7 +498,7 @@ using (var call = client.RouteChat())
 
 #### Using Visual Studio
 
-- Open the solution `examples/csharp/route_guide/RouteGuide.sln` and select **Build**.
+- Open the solution `examples/csharp/RouteGuide/RouteGuide.sln` and select **Build**.
 
 #### Using Xamarin Studio or Monodevelop on OS X or Linux
 

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -55,8 +55,8 @@ $ cd grpc
 
 All the files for this tutorial are in the directory
 `examples/csharp/RouteGuide`. Open the solution
-`examples/csharp/RouteGuide/RouteGuide.sln` from Visual Studio, Monodevelop or
-Xamarin Studio. For additional installation details, see the [How to use
+`examples/csharp/RouteGuide/RouteGuide.sln` from Visual Studio (Windows or Mac) or Visual Studio Code.
+For additional installation details, see the [How to use
 instructions](https://github.com/grpc/grpc/tree/
 {{ site.data.config.grpc_release_tag }}/src/csharp#how-to-use).
 
@@ -496,30 +496,28 @@ using (var call = client.RouteChat())
 
 ### Build the client and server:
 
-#### Using Visual Studio
+#### Using Visual Studio (or Visual Studio For Mac)
 
 - Open the solution `examples/csharp/RouteGuide/RouteGuide.sln` and select **Build**.
 
-#### Using Xamarin Studio or Monodevelop on OS X or Linux
+#### Using "dotnet" command line tool
 
-- See the [quickstart](../../quickstart/csharp.html) for instructions on downloading gRPC
-  nuget dependencies and building the solution with these IDEs.
+- Run `dotnet build RouteGuide.sln` from the `examples/csharp/RouteGuide` directory.
+  See the [quickstart](../../quickstart/csharp.html) for additional instructions on building 
+  the gRPC example with the `dotnet` command line tool.
 
 Run the server, which will listen on port 50052:
 
 ```
-> cd RouteGuideServer/bin/Debug
-> RouteGuideServer.exe
+> cd RouteGuideServer/bin/Debug/netcoreapp1.0
+> dotnet exec RouteGuideServer.dll
 ```
 
 Run the client (in a different terminal):
 
 ```
-> cd RouteGuideClient/bin/Debug
-> RouteGuideClient.exe
+> cd RouteGuideClient/bin/Debug/netcoreapp1.0
+> dotnet exec RouteGuideClient.dll
 ```
 
 You can also run the server and client directly from Visual Studio.
-
-On Linux or Mac, use `mono RouteGuideServer.exe` and `mono RouteGuideClient.exe`
-to run the server and client.

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -156,7 +156,7 @@ If you want to run this yourself, the `Grpc.Tools` NuGet package contains the
 binaries you will need to generate the code. You can fetch a copy of
 the `Grpc.Tools` package into your local nuget cache by clicking
 "Restore NuGet Packages" in Visual Studio or running `dotnet restore RouteGuide.sln`
-from the `examples/csharp/RouteGuide`.
+from the `examples/csharp/RouteGuide` directory.
 
 Once that's done, you can generate the C# code:
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16397

We should hold merging until v1.15.0 is released (~about two weeks from now), because the changes to C# examples from https://github.com/grpc/grpc/pull/16144  won't be propagated to the release branch until then.