### PR TITLE
Remove linked helloworld - it's not "Go Secure"

### DIFF
--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -8,7 +8,6 @@ type: markdown
 <p class="lead">Here are some sample apps to help developers build certain functionalities</p>
 
 <ul>
-  <li><a target="_blank" href="https://github.com/kelseyhightower/helloworld">Go Secure Hello World Example</a></li>
   <li><a target="_blank" href="https://github.com/GoogleCloudPlatform/ios-docs-samples/tree/master/speech/Objective-C/Speech-gRPC-Streaming">Bidirectional streaming iOS client using Cloud Speech API</a></li>
   <li><a target="_blank" href="https://github.com/david-cao/gRPCBenchmarks">Android app benchmarking JSON/HTTP/1.1 and gRPC</a></li>
 </ul>


### PR DESCRIPTION
https://github.com/kelseyhightower/helloworld is just a basic http server, having it linked here just confuses people.