### PR TITLE
Update ruby.md - Fix client code example

### DIFF
--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -314,7 +314,7 @@ To call service methods, we first need to create a *stub*.
 We use the `Stub` class of the `RouteGuide` module generated from our .proto.
 
 ```ruby
-stub = RouteGuide::Stub.new('localhost:50051')
+stub = RouteGuide::Stub.new('localhost:50051', :this_channel_is_insecure)
 ```
 
 ### Calling service methods


### PR DESCRIPTION
Add missing second argument (`:this_channel_is_insecure`) to `RouteGuide::Stub.new` call.