### PR TITLE
csharp.md: changes to mac os build instructions.

### DIFF
--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -164,7 +164,7 @@ protoc-gen-grpc plugin requires fullpath of "grpc_csharp_plugin" executable inst
 
 ```
 # Local nuget cache on Linux and Mac is located in ~/.nuget/packages
-$ ~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=/Users/<HOME_FOLDER>/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
+$ ~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=${HOME}/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
 ```
 
 Running the appropriate command for your OS regenerates the following files in

--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -159,10 +159,12 @@ From the `examples/csharp/Helloworld` directory:
 ```
 
 **Linux (or OS X by using macosx_x64 directory)**
+Note:
+protoc-gen-grpc plugin requires fullpath of "grpc_csharp_plugin" executable instead of short form with "~" symbol. Make sure to change <HOME_FOLDER phrase in below command according to your local machine.
 
 ```
 # Local nuget cache on Linux and Mac is located in ~/.nuget/packages
-$ ~/.nuget/packages/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
+$ ~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=/Users/<HOME_FOLDER>/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
 ```
 
 Running the appropriate command for your OS regenerates the following files in


### PR DESCRIPTION
removed extra packages folder from path
updated command to reflect full path for "grpc_csharp_plugin"..
protoc-gen-grpc plugin requires fullpath of "grpc_csharp_plugin" executable instead of short form with "~". Make sure to change <HOME_FOLDER phrase in below command according to your local machine.