### PR TITLE
update node docs to use addService

### DIFF
--- a/docs/quickstart/node.md
+++ b/docs/quickstart/node.md
@@ -127,7 +127,7 @@ function sayHelloAgain(call, callback) {
 
 function main() {
   var server = new grpc.Server();
-  server.addProtoService(hello_proto.Greeter.service,
+  server.addService(hello_proto.Greeter.service,
                          {sayHello: sayHello, sayHelloAgain: sayHelloAgain});
   server.bind('0.0.0.0:50051', grpc.ServerCredentials.createInsecure());
   server.start();

--- a/docs/quickstart/php.md
+++ b/docs/quickstart/php.md
@@ -400,7 +400,7 @@ function sayHelloAgain(call, callback) {
 
 function main() {
   var server = new grpc.Server();
-  server.addProtoService(hello_proto.Greeter.service,
+  server.addService(hello_proto.Greeter.service,
                          {sayHello: sayHello, sayHelloAgain: sayHelloAgain});
   server.bind('0.0.0.0:50051', grpc.ServerCredentials.createInsecure());
   server.start();

--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -349,7 +349,7 @@ do this for our `RouteGuide` service:
 ```js
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(routeguide.RouteGuide.service, {
+  server.addService(routeguide.RouteGuide.service, {
     getFeature: getFeature,
     listFeatures: listFeatures,
     recordRoute: recordRoute,


### PR DESCRIPTION
small change to the docs now that the node server api has changed

link to api: https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/server.js#L948

the examples work with or without this change, but the change removes this warning message:
```
$ node server.js
(node:44083) DeprecationWarning: Server#addProtoService: Use Server#addService instead
```