### PR TITLE
Add link to release schedule

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -98,15 +98,15 @@ headline: 'Frequently Asked Questions'
                         </div>
                     </li>
                     <li class="submenu">
-                        <h6 class="arrow-r">How long are gRPC releases supported for?</h6>
+                        <h6 class="arrow-r">When do gRPC releases happen?</h6>
                         <div class="submenu-content">
-                            <p>The gRPC project does not do LTS releases. Given the rolling release model above, we support the current, latest release and the release prior to that. Support here means bug fixes and security fixes.</p>
+                          <p>The gRPC project works in a model where the tip of the master branch is stable at all times. The project (across the various runtimes) targets to ship checkpoint releases every 6 weeks on a best effort basis. See the release schedule <a target="_blank" href="https://github.com/grpc/grpc/blob/master/doc/grpc_release_schedule.md">here</a>.</p>
                         </div>
                     </li>
                     <li class="submenu">
-                        <h6 class="arrow-r">When do gRPC releases happen?</h6>
+                        <h6 class="arrow-r">How long are gRPC releases supported for?</h6>
                         <div class="submenu-content">
-                            <p>The gRPC project works in a model where the tip of the master branch is stable at all times. The project (across the various runtimes) targets to ship checkpoint releases every 6 weeks on a best effort basis. If for some reason, a release is skipped by a particular runtime, we may opt to skip that release altogether, and ship the next release, along with the other runtimes and catch up.</p>
+                            <p>The gRPC project does not do LTS releases. Given the rolling release model above, we support the current, latest release and the release prior to that. Support here means bug fixes and security fixes.</p>
                         </div>
                     </li>
                     <li class="submenu">


### PR DESCRIPTION
Added link to gRPC release schedule and swapped the order of "When do gRPC releases happen?" and "How long are gRPC releases supported for?"