### PR TITLE
fix title

### DIFF
--- a/_posts/2018-08-20-grpc-on-http2.md
+++ b/_posts/2018-08-20-grpc-on-http2.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: gRPC on HTTP/2: Engineering a Robust, High Performance Protocol
+title: gRPC on HTTP/2 Engineering a Robust, High Performance Protocol
 published: true
 permalink: blog/grpc_on_http2
 author: Jean de Klerk


### PR DESCRIPTION
For reasons unknown, GitHub's parser doesn't like the colon char.

cc @jadekler 