### PR TITLE
The path to Grpc.Tools in the example command for Linux(or macOS) does not exist

### DIFF
--- a/docs/quickstart/csharp.md
+++ b/docs/quickstart/csharp.md
@@ -164,7 +164,7 @@ protoc-gen-grpc plugin requires fullpath of "grpc_csharp_plugin" executable inst
 
 ```
 # Local nuget cache on Linux and Mac is located in ~/.nuget/packages
-$ ~/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=${HOME}/.nuget/packages/grpc.tools.{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
+$ ~/.nuget/packages/grpc.tools/{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/protoc -I../../protos --csharp_out Greeter --grpc_out Greeter ../../protos/helloworld.proto --plugin=protoc-gen-grpc=${HOME}/.nuget/packages/grpc.tools/{{ site.data.config.grpc_release_tag | remove_first: "v" }}/tools/linux_x64/grpc_csharp_plugin
 ```
 
 Running the appropriate command for your OS regenerates the following files in


### PR DESCRIPTION
Hey,

I belive there is a mistake in the path to Grpc.Tools in the example command for Linux in the documentation. When I tried running the example command displayed on the page (look below) I got an error saying that the path does not exist. It worked when I replaced the dot after *tools* in the current path (`~.nuget/packages/grpc.tools.1.16.0/`)  with a slash, which resulted in a valid path: `~/.nuget/packages/grpc.tools/1.16.0/`