### PR TITLE
Revert "Update to account for import error in generated python code"

### DIFF
--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -71,7 +71,7 @@ tutorials and your own projects.
 To install gRPC tools, run:
 
 ```sh
-$ python -m pip install grpcio-tools googleapis-common-protos
+$ python -m pip install grpcio-tools
 ```
 
 ## Download the example

--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -158,13 +158,6 @@ First, install the grpcio-tools package:
 $ pip install grpcio-tools
 ```
 
-Then, install the googleapis-common-proto package which is a collection of
-generated python classes for some common protos:
-
-```
-$ pip install googleapis-common-protos
-```
-
 Use the following command to generate the Python code:
 
 ```


### PR DESCRIPTION
This reverts commit d9c953d22bb59f07d01e90053fee1673252e582c.

cc @hsaliak I'm not sure why this PR was merged. Unless I'm missing something, the reported error was because the *user's* protobuf file (not grpcio-tools itself) had a dependency on googleapis-common-protos. They should add this to their project's dependencies, it's not something required to use grpcio-tools or our quickstart or tutorial code.