### PR TITLE
Run the gradle wrapper in examples root directory

### DIFF
--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -57,7 +57,7 @@ $ cd grpc-java/examples
 
    ```sh
    $ cd android/helloworld
-   $ ./gradlew installDebug
+   $ ../../gradlew installDebug
    ```
 
 Congratulations! You've just run a client-server application with gRPC.
@@ -170,7 +170,7 @@ Just like we did before, from the `examples` directory:
 
    ```sh
    $ cd android/helloworld
-   $ ./gradlew installDebug
+   $ ../../gradlew installDebug
    ```
 
 #### Connecting to the Hello World server via USB


### PR DESCRIPTION
The project gradle wrapper is about to be removed https://github.com/grpc/grpc-java/pull/5141