### PR TITLE
Take Dart gRPC to 1.0 stable

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -183,9 +183,9 @@ headline: 'About gRPC'
             </div>
         </div>
         <div class="platforms-table-row">
-            <div class="col-sm-4 col-xs-2 platforms-table-cell">Dart *</div>
+            <div class="col-sm-4 col-xs-2 platforms-table-cell">Dart</div>
             <div class="col-sm-4 col-xs-6 platforms-table-cell">Windows/Linux/Mac</div>
-            <div class="col-sm-4 col-xs-4 platforms-table-cell">Dart 1.24.3+</div>
+            <div class="col-sm-4 col-xs-4 platforms-table-cell">Dart 2.0+</div>
         </div>
         <div class="platforms-table-row">
             <div class="col-sm-4 col-xs-2 platforms-table-cell">Go</div>

--- a/docs/quickstart/dart.md
+++ b/docs/quickstart/dart.md
@@ -10,12 +10,6 @@ working example.</p>
 
 <div id="toc"></div>
 
-## Before you begin
-
-<p class="note">Dart gRPC is currently in beta. Please help us out by
-<a href="https://github.com/grpc/grpc-dart/issues/new">filing issues</a>
-if you encounter any.</p>
-
 ### Prerequisites
 
 #### Dart SDK
@@ -233,3 +227,8 @@ Just like we did before, from the `example/helloworld` directory:
 
 [gRPC Basics: Dart]:../tutorials/basic/dart.html
 
+
+## Reporting issues
+Should you encounter an issue, please help us out by
+<a href="https://github.com/grpc/grpc-dart/issues/new">filing issues</a>
+in our issue tracker.</p>

--- a/docs/tutorials/basic/dart.md
+++ b/docs/tutorials/basic/dart.md
@@ -8,10 +8,6 @@ type: markdown
 <p class="lead">This tutorial provides a basic Dart programmer's introduction to
 working with gRPC.</p>
 
-<p class="note">Dart gRPC is currently in beta. Please help us out by
-<a href="https://github.com/grpc/grpc-dart/issues/new">filing issues</a>
-if you encounter any.</p>
-
 By walking through this example you'll learn how to:
 
 - Define a service in a .proto file.
@@ -546,3 +542,10 @@ Likewise, to run the client:
 ```sh
 $ dart bin/client.dart
 ```
+
+## Reporting issues
+
+Should you encounter an issue, please help us out by
+<a href="https://github.com/grpc/grpc-dart/issues/new">filing issues</a>
+in our issue tracker.</p>
+


### PR DESCRIPTION
We published a 1.0 version of the Dart gRPC package: https://pub.dartlang.org/packages/grpc#-analysis-tab-

This updated the documentation to remove statements that Dart is still in beta.