### PR TITLE
Fixes in route guide protobuf intro

### DIFF
--- a/docs/tutorials/basic/c.md
+++ b/docs/tutorials/basic/c.md
@@ -17,13 +17,11 @@ It assumes that you have read the [Overview](/docs/index.html) and are familiar
 with [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
-buffers language, which is currently in beta release: you can find out more in
+buffers language: you can find out more in
 the [proto3 language
 guide](https://developers.google.com/protocol-buffers/docs/proto3) and [C++
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/csharp.md
+++ b/docs/tutorials/basic/csharp.md
@@ -17,11 +17,9 @@ By walking through this example you'll learn how to:
 It assumes that you have read the [Overview](/docs/index.html) and are familiar
 with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). Note that the
 example in this tutorial uses the proto3 version of the protocol buffers
-language, which is currently in beta release: you can find out more in the
+language: you can find out more in the
 [proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3) and 
 [C# generated code reference](https://developers.google.com/protocol-buffers/docs/reference/csharp-generated).
-For information about the new version in the protocol buffers GitHub repository,
-see the [release notes](https://github.com/google/protobuf/releases).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/dart.md
+++ b/docs/tutorials/basic/dart.md
@@ -17,11 +17,9 @@ By walking through this example you'll learn how to:
 It assumes that you have read the [Overview](/docs/index.html) and are familiar
 with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). Note that the
 example in this tutorial uses the proto3 version of the protocol buffers
-language, which is currently in beta release: you can find out more in the
+language: you can find out more in the
 [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/proto3).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -17,13 +17,11 @@ By walking through this example you'll learn how to:
 It assumes that you have read the [Overview](/docs/index.html) and are familiar
 with [protocol buffers](https://developers.google.com/protocol-buffers/docs/overview). Note that the
 example in this tutorial uses the proto3 version of the protocol buffers
-language, which is currently in beta release: you can find out more in the
+language: you can find out more in the
 [proto3 language
 guide](https://developers.google.com/protocol-buffers/docs/proto3) and the [Go
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/go-generated),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/reference/go-generated).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/java.md
+++ b/docs/tutorials/basic/java.md
@@ -22,9 +22,7 @@ that the example in this tutorial uses the
 buffers language: you can find out more in the [proto3 language
 guide](https://developers.google.com/protocol-buffers/docs/proto3) and [Java
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/java-generated),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/reference/java-generated).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -19,9 +19,7 @@ buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
 that the example in this tutorial uses the
 [proto3](https://github.com/google/protobuf/releases) version of the protocol
 buffers language. You can find out more in the
-[proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3)
-and see the [release notes](https://github.com/google/protobuf/releases) for
-the new version in the protocol buffers GitHub repository.
+[proto3 language guide](https://developers.google.com/protocol-buffers/docs/proto3).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/objective-c.md
+++ b/docs/tutorials/basic/objective-c.md
@@ -17,13 +17,11 @@ By walking through this example you'll learn how to:
 It assumes a passing familiarity with [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
-buffers language, which is currently in beta release: you can find out more in
+buffers language: you can find out more in
 the [proto3 language
 guide](https://developers.google.com/protocol-buffers/docs/proto3) and the
 [Objective-C generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/objective-c-generated),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/reference/objective-c-generated).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/python.md
+++ b/docs/tutorials/basic/python.md
@@ -20,9 +20,7 @@ buffers](https://developers.google.com/protocol-buffers/docs/overview). You can
 find out more in the [proto3 language
 guide](https://developers.google.com/protocol-buffers/docs/proto3) and [Python
 generated code
-guide](https://developers.google.com/protocol-buffers/docs/reference/python-generated),
-and see the [release notes](https://github.com/google/protobuf/releases) for the
-new version in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/reference/python-generated).
 
 <div id="toc"></div>
 

--- a/docs/tutorials/basic/ruby.md
+++ b/docs/tutorials/basic/ruby.md
@@ -17,11 +17,9 @@ It assumes that you have read the [Overview](/docs/index.html) and are familiar
 with [protocol
 buffers](https://developers.google.com/protocol-buffers/docs/overview). Note
 that the example in this tutorial uses the proto3 version of the protocol
-buffers language, which is currently in alpha release: you can find out more in
+buffers language: you can find out more in
 the [proto3 language
-guide](https://developers.google.com/protocol-buffers/docs/proto3) and see the
-[release notes](https://github.com/google/protobuf/releases) for the new version
-in the protocol buffers GitHub repository.
+guide](https://developers.google.com/protocol-buffers/docs/proto3).
 
 <div id="toc"></div>
 


### PR DESCRIPTION
Proto3 haven't been in beta for a while, also removing the link to protobuf release notes which doesn't seem useful anymore for that reason.