### PR TITLE
Fix broken Zipkin link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -156,7 +156,7 @@ bodyclass: docs
           <a class="lang-card-link" href="https://github.com/go-kit/kit/tree/master/transport/grpc">Go kit with gRPC transport</a>
           <a class="lang-card-link" href="https://github.com/coreos/etcd">CoreOS etcd</a>
           <a class="lang-card-link" href="https://github.com/cockroachdb/cockroach">cockroachdb</a>
-          <a class="lang-card-link" href="https://github.com/openzipkin/brave/tree/master/archive/brave-grpc">Zipkin for gRPC</a>
+          <a class="lang-card-link" href="https://github.com/openzipkin/brave/tree/master/instrumentation/grpc">Zipkin for gRPC</a>
           <a class="lang-card-link" href="https://github.com/pingcap/tidb">TiDB</a>
           <a class="lang-card-link" href="https://github.com/apache/bookkeeper">Apache BookKeeper</a>
         </div>


### PR DESCRIPTION
Fixes the Zipkin GitHub link leading to a deleted file.

Old Link:
- https://github.com/openzipkin/brave/tree/master/archive/brave-grpc

New Link
- https://github.com/openzipkin/brave/tree/master/instrumentation/grpc