### PR TITLE
Fixing documentation typo

### DIFF
--- a/docs/tutorials/basic/node.md
+++ b/docs/tutorials/basic/node.md
@@ -385,7 +385,7 @@ need to call the RouteGuide stub constructor, specifying the server address and
 port.
 
 ```js
-new example.RouteGuide('localhost:50051', grpc.credentials.createInsecure());
+new routeguide.RouteGuide('localhost:50051', grpc.credentials.createInsecure());
 ```
 
 ### Calling service methods


### PR DESCRIPTION
The stub is actually held in a var called "routeguide" and not "example". This change makes it consistent as per the rest of this documentation and the full sample code.