### PR TITLE
Fix link to detailed C++ performance dashboard.

### DIFF
--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -25,7 +25,7 @@ visualization.
 
   * [Multi-language performance dashboard @latest_release (lastest available stable release)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5636470266134528) 
   * [Multi-language performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5652536396611584)
-  * [C++ detailed performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5632763172487168)
+  * [C++ detailed performance dashboard @master (latest dev version)](https://performance-dot-grpc-testing.appspot.com/explore?dashboard=5685265389584384)
 
 Additional benchmarking provides fine grained insights into where
 CPU is spent.


### PR DESCRIPTION
The old link leads to a personal dashboard of a team member (and there's no data).