### PR TITLE
Update go client streaming example

### DIFF
--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -510,7 +510,9 @@ if err != nil {
 }
 for _, point := range points {
 	if err := stream.Send(point); err != nil {
-		_, err := stream.CloseAndRecv()
+		if err == io.EOF {
+			break
+		}
 		log.Fatalf("%v.Send(%v) = %v", stream, point, err)
 	}
 }

--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -510,6 +510,7 @@ if err != nil {
 }
 for _, point := range points {
 	if err := stream.Send(point); err != nil {
+		_, err := stream.CloseAndRecv()
 		log.Fatalf("%v.Send(%v) = %v", stream, point, err)
 	}
 }


### PR DESCRIPTION
When the server returns an error during a client-streaming RPC the error on the client side will be `io.EOF` in order to get the real message back from the server you need to call stream.CloseAndRecv() and then log that.
