### PR TITLE
Fix go client bidirectional example

### DIFF
--- a/docs/tutorials/basic/go.md
+++ b/docs/tutorials/basic/go.md
@@ -558,8 +558,8 @@ for _, note := range notes {
 		log.Fatalf("Failed to send a note: %v", err)
 	}
 }
-stream.CloseSend()
 <-waitc
+stream.CloseSend()
 ```
 
 The syntax for reading and writing here is very similar to our client-side


### PR DESCRIPTION
In the example of handling bidirectional streaming in the client side,
stream.CloseSend() was called before <-waitc which makes no sense. It
should be the other way around