### PR TITLE
Drop /release

### DIFF
--- a/release
+++ b/release
@@ -1,5 +1,0 @@
----
-permalink: /release
----
-
-{{ site.data.config.grpc_release_tag }}


### PR DESCRIPTION
Contributes to https://github.com/grpc/grpc.io/pull/542 cleanup. This site is obsolete, so /release shouldn't be used.